### PR TITLE
fixing issue of setting language flag in ner script

### DIFF
--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -38,9 +38,7 @@ from transformers import (
     set_seed,
     setup_task_adapter_training,
 )
-
 from utils_ner import NerDataset, Split, get_labels
-
 
 
 logger = logging.getLogger(__name__)
@@ -80,7 +78,7 @@ class DataTrainingArguments:
     )
     labels: Optional[str] = field(
         default=None,
-        metadata={"help": "Path to a file containing all labels. If not specified, CoNLL-2003 labels are used."}
+        metadata={"help": "Path to a file containing all labels. If not specified, CoNLL-2003 labels are used."},
     )
     max_seq_length: int = field(
         default=128,
@@ -175,7 +173,7 @@ def main():
     if adapter_args.train_adapter:
         language = None
         for k, v in model.config.adapters.adapters.items():
-            if v[0] == 'text_lang':
+            if v[0] == "text_lang":
                 language = k
         if language:
             adapter_names = [[language], [task_name]]

--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -38,7 +38,9 @@ from transformers import (
     set_seed,
     setup_task_adapter_training,
 )
+
 from utils_ner import NerDataset, Split, get_labels
+
 
 
 logger = logging.getLogger(__name__)
@@ -77,6 +79,7 @@ class DataTrainingArguments:
         metadata={"help": "The input data dir. Should contain the .txt files for a CoNLL-2003-formatted task."}
     )
     labels: Optional[str] = field(
+        default=None,
         metadata={"help": "Path to a file containing all labels. If not specified, CoNLL-2003 labels are used."}
     )
     max_seq_length: int = field(
@@ -168,13 +171,17 @@ def main():
 
     # Setup adapters
     task_name = "ner"
-    language = adapter_args.language
     setup_task_adapter_training(model, task_name, adapter_args)
     if adapter_args.train_adapter:
+        language = None
+        for k, v in model.config.adapters.adapters.items():
+            if v[0] == 'text_lang':
+                language = k
         if language:
             adapter_names = [[language], [task_name]]
         else:
             adapter_names = [[task_name]]
+
     else:
         adapter_names = None
 

--- a/src/transformers/adapter_training.py
+++ b/src/transformers/adapter_training.py
@@ -52,9 +52,7 @@ def setup_task_adapter_training(model, task_name: str, adapter_args: AdapterArgu
             # TODO support different non_linearity & reduction_factor
             lconfig = AdapterConfig.load(lconfig_string, non_linearity="gelu", reduction_factor=2)
 
-            model.load_adapter(
-                adapter_args.load_lang_adapter, AdapterType.text_lang, config=lconfig
-            )
+            model.load_adapter(adapter_args.load_lang_adapter, AdapterType.text_lang, config=lconfig)
         # enable adapter training
         base_model.train_adapter([task_name])
     # set adapters as default if possible

--- a/src/transformers/adapter_training.py
+++ b/src/transformers/adapter_training.py
@@ -22,9 +22,6 @@ class AdapterArguments:
     )
     adapter_config: Optional[str] = field(default="pfeiffer", metadata={"help": "Adapter configuration."})
     lang_adapter_config: Optional[str] = field(default=None, metadata={"help": "Language adapter configuration."})
-    language: Optional[str] = field(
-        default=None, metadata={"help": "The adapter name of the loaded language adapter, e.g. 'en' for english."}
-    )
 
 
 def setup_task_adapter_training(model, task_name: str, adapter_args: AdapterArguments):
@@ -56,7 +53,7 @@ def setup_task_adapter_training(model, task_name: str, adapter_args: AdapterArgu
             lconfig = AdapterConfig.load(lconfig_string, non_linearity="gelu", reduction_factor=2)
 
             model.load_adapter(
-                adapter_args.load_lang_adapter, AdapterType.text_lang, config=lconfig, load_as=adapter_args.language
+                adapter_args.load_lang_adapter, AdapterType.text_lang, config=lconfig
             )
         # enable adapter training
         base_model.train_adapter([task_name])


### PR DESCRIPTION
`language` flag causes error when not loading a language adapter. Fixed by no longer setting `language` and instead extracting the language `adapter_name` directly from the adapter config. 