### PR TITLE
unfreezed layernorms of Bert encoders in houlsby architecture

### DIFF
--- a/src/transformers/adapter_config.py
+++ b/src/transformers/adapter_config.py
@@ -153,8 +153,8 @@ class HoulsbyConfig(AdapterConfig):
     ln_after: bool = False
     mh_adapter: bool = True
     output_adapter: bool = True
-    non_linearity: str = "swish"
-    reduction_factor: int = 16
+    non_linearity: str = "gelu"
+    reduction_factor: int = 12
 
 
 ADAPTER_CONFIG_MAP = {"pfeiffer": PfeifferConfig(), "houlsby": HoulsbyConfig()}

--- a/src/transformers/adapter_model_mixin.py
+++ b/src/transformers/adapter_model_mixin.py
@@ -891,8 +891,14 @@ class ModelAdaptersMixin(ABC):
         """Freezes all weights of the model.
         """
         # first freeze/ unfreeze all model weights
-        for param in self.base_model.parameters():
-            param.requires_grad = not freeze
+        if self.config.adapters.config_map['text_task'] == "houlsby":
+            for param in self.base_model.named_parameters():
+                if "encoder" in param[0] and "LayerNorm" in param[0]:
+                    continue
+                param[1].requires_grad = not freeze
+        else:
+            for param in self.base_model.parameters():
+                param.requires_grad = not freeze
         self.model_freezed = freeze
 
 


### PR DESCRIPTION
According to Houlsby's [paper](https://arxiv.org/abs/1902.00751), during adapter tuning, the layer normalization layers of BERT encoders should be trained on the downstream task.