### PR TITLE
Add active_adapters to all model classes with adapters

### DIFF
--- a/src/transformers/adapter_bert.py
+++ b/src/transformers/adapter_bert.py
@@ -7,7 +7,7 @@ from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 from .adapter_config import DEFAULT_ADAPTER_CONFIG, AdapterType
 from .adapter_model_mixin import ModelAdaptersMixin, ModelWithHeadsAdaptersMixin
 from .adapter_modeling import Activation_Function_Class, Adapter, BertFusion, GLOWCouplingBlock, NICECouplingBlock
-from .adapter_utils import parse_adapter_names
+from .adapter_utils import flatten_adapter_names, parse_adapter_names
 
 
 logger = logging.getLogger(__name__)
@@ -519,18 +519,24 @@ class BertModelAdaptersMixin(ModelAdaptersMixin):
         """Sets the model in mode for training the given adapters."""
         self.train()
         self.freeze_model(True)
+        adapter_names_flat = flatten_adapter_names(adapter_names)
         self.encoder.enable_adapters(adapter_names, True, False)
         # unfreeze invertible adapters for invertible adapters
-        for adapter_name in adapter_names:
+        for adapter_name in adapter_names_flat:
             if adapter_name in self.invertible_lang_adapters:
                 for param in self.invertible_lang_adapters[adapter_name].parameters():
                     param.requires_grad = True
+        # use the adapters to be trained by default in every forward pass
+        self.set_active_adapters(adapter_names)
 
     def train_fusion(self, adapter_names: list):
         """Sets the model in mode for training of adapter fusion determined by a list of adapter names."""
         self.train()
         self.freeze_model(True)
-        self.encoder.enable_adapters(adapter_names, False, True)
+        adapter_names_flat = flatten_adapter_names(adapter_names)
+        self.encoder.enable_adapters(adapter_names_flat, False, True)
+        # use the adapters to be trained by default in every forward pass
+        self.set_active_adapters(adapter_names)
         # TODO implement fusion for invertible adapters
 
     def add_adapter(self, adapter_name: str, adapter_type: AdapterType, config=None):
@@ -592,7 +598,6 @@ class BertModelHeadsMixin(ModelWithHeadsAdaptersMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.active_adapter_names = None
         self.active_head = None
 
     def _init_head_modules(self):
@@ -604,32 +609,22 @@ class BertModelHeadsMixin(ModelWithHeadsAdaptersMixin):
             self._add_prediction_head_module(head_name)
 
     def set_active_adapters(self, adapter_names: list):
-        """Sets the task adapter and/ or prediction head which should be used by default in a forward pass.
-        If no adapter or prediction with the given name is found, no module of the respective type will be activated.
+        """Sets the adapter modules to be used by default in every forward pass.
+        This setting can be overriden by passing the `adapter_names` parameter in the `foward()` pass.
+        If no adapter with the given name is found, no module of the respective type will be activated.
+        In case the calling model class supports named prediction heads, this method will attempt to activate a prediction head with the name of the last adapter in the list of passed adapter names.
 
         Args:
-            task_name (str): The name of the task adapter and/ or prediction head.
+            adapter_names (list): The list of adapters to be activated by default. Can be a fusion or stacking configuration.
         """
-        adapter_names = parse_adapter_names(adapter_names)
-
-        new_adapter_names = []
-
-        for stack in adapter_names:
-            new_adapter_names.append([])
-            for adapter_name in stack:
-                if adapter_name in self.config.adapters.adapter_list(
-                    AdapterType.text_task
-                ) or adapter_name in self.config.adapters.adapter_list(AdapterType.text_lang):
-                    new_adapter_names[-1].append(adapter_name)
-                else:
-                    logger.info("No task adapter for task_name '{}' available. Removing it.".format(adapter_name))
-                if adapter_name in self.config.prediction_heads:
-                    self.active_head = adapter_name
-                else:
-                    logger.info("No prediction head for task_name '{}' available.".format(adapter_name))
-        if len(new_adapter_names[0]) == 0:
-            new_adapter_names = None
-        self.active_adapter_names = new_adapter_names
+        self.base_model.set_active_adapters(adapter_names)
+        # use last adapter name as name of prediction head
+        if self.active_adapters:
+            head_name = self.active_adapters[-1][-1]
+            if head_name in self.config.prediction_heads:
+                self.active_head = head_name
+            else:
+                logger.info("No prediction head for task_name '{}' available.".format(head_name))
 
     def add_classification_head(
         self, head_name, num_labels=2, layers=2, activation_function="tanh", overwrite_ok=False, multilabel=False
@@ -735,7 +730,7 @@ class BertModelHeadsMixin(ModelWithHeadsAdaptersMixin):
     def forward_head(self, outputs, head_name=None, attention_mask=None, labels=None):
         head_name = head_name or self.active_head
         if not head_name:
-            logger.warn("No prediction head is used.")
+            logger.debug("No prediction head is used.")
             return outputs
 
         if head_name not in self.config.prediction_heads:

--- a/src/transformers/adapter_utils.py
+++ b/src/transformers/adapter_utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import itertools
 import json
 import logging
 import os
@@ -10,7 +11,7 @@ from dataclasses import asdict, is_dataclass
 from enum import Enum
 from os.path import basename, isdir, isfile, join
 from pathlib import Path
-from typing import Callable, Optional, Union
+from typing import Callable, List, Optional, Union
 from urllib.parse import urlparse
 from zipfile import ZipFile, is_zipfile
 
@@ -82,7 +83,11 @@ def get_adapter_config_hash(config, length=16):
     return h.hexdigest()[:length]
 
 
-def parse_adapter_names(adapter_names):
+def flatten_adapter_names(adapter_names: List[List[str]]) -> List[str]:
+    return list(itertools.chain(*adapter_names))
+
+
+def parse_adapter_names(adapter_names: list) -> List[List[str]]:
     if adapter_names is not None:
         if isinstance(adapter_names, str):
             adapter_names = [[adapter_names]]

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -718,6 +718,8 @@ class BertModel(BertModelAdaptersMixin, BertPreTrainedModel):
         last_hidden_states = outputs[0]  # The last hidden-state is the first element of the output tuple
 
         """
+        # override the default active adapters with those passed in the method call
+        adapter_names = adapter_names or self.active_adapters
         # some warnings if we don't use available adapters
         if not adapter_names and self.has_adapters():
             logger.warning("There are adapters available but none are passed to model.forward")
@@ -820,7 +822,6 @@ class BertModelWithHeads(BertModelHeadsMixin, BertPreTrainedModel):
         token_type_ids = token_type_ids.view(-1, token_type_ids.size(-1)) if token_type_ids is not None else None
         position_ids = position_ids.view(-1, position_ids.size(-1)) if position_ids is not None else None
 
-        adapter_names = adapter_names or self.active_adapter_names
         outputs = self.bert(
             input_ids,
             attention_mask=attention_mask,

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -195,8 +195,6 @@ class RobertaModelWithHeads(BertModelHeadsMixin, BertPreTrainedModel):
         token_type_ids = token_type_ids.view(-1, token_type_ids.size(-1)) if token_type_ids is not None else None
         position_ids = position_ids.view(-1, position_ids.size(-1)) if position_ids is not None else None
 
-        adapter_names = adapter_names or self.active_adapter_names
-
         outputs = self.roberta(
             input_ids,
             attention_mask=attention_mask,


### PR DESCRIPTION
- Adds a `set_active_adapters()` method to all model classes supporting adapters
- Automatically set active adapters in calls to `train_*()` methods, e.g. calling `model.train_adapter("mnli")` will also set the adapter "mnli" as default in every forward pass additionally to unfreezing it.

_Squash before merging!_