### PR TITLE
Improvements for example scripts

### DIFF
--- a/adapter_docs/quickstart.md
+++ b/adapter_docs/quickstart.md
@@ -15,7 +15,7 @@ storing (e.g. `save_adapter()`) are added to the model classes. In the following
 
 ## Quick Tour: Using a pre-trained adapter for inference
 
-_There's also a quickstart Colab notebook for adapter inference: [Try it out!](https://colab.research.google.com/github/Adapter-Hub/website/blob/master/app/static/notebooks/Adapter_Quickstart_Inference.ipynb)_
+_We also have a Quickstart Colab notebook for adapter inference:_ [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Adapter-Hub/website/blob/master/app/static/notebooks/Adapter_Quickstart_Inference.ipynb)
 
 The following example shows the usage of a basic pre-trained transformer model with adapters.
 Our goal here is to predict the sentiment of a given sentence.
@@ -82,6 +82,6 @@ Similar to how the weights of the full model are saved, the `save_adapter()` wil
 
 ## Quick Tour: Adapter training
 
-_There's also a quickstart Colab notebook for adapter training: [Try it out!](https://colab.research.google.com/github/Adapter-Hub/website/blob/master/app/static/notebooks/Adapter_Quickstart_Training.ipynb)_
+_We also have a Quickstart Colab notebook for adapter training:_ [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Adapter-Hub/website/blob/master/app/static/notebooks/Adapter_Quickstart_Training.ipynb)
 
 For more examples on training different adapter setups, refer to the section on [Adapter Training](training.md).

--- a/adapter_docs/training.md
+++ b/adapter_docs/training.md
@@ -63,7 +63,7 @@ model.set_active_adapters(task_name)
 The rest of the training procedure does not require any further changes in code.
 
 You can find the full version of the modified training script for GLUE at [run_glue_alt.py](https://github.com/Adapter-Hub/adapter-transformers/blob/master/examples/text-classification/run_glue_alt.py) in the `examples` folder of our repository.
-We also adapted various other example scripts (e.g. `run_glue.py`, `run_multiple_choice.py`, `run_squad.py`, ...) to support adapter training.
+We also adapted [various other example scripts](https://github.com/Adapter-Hub/adapter-transformers/tree/master/examples) (e.g. `run_glue.py`, `run_multiple_choice.py`, `run_squad.py`, ...) to support adapter training.
 
 To start adapter training on a GLUE task, you can run something similar to:
 

--- a/adapter_docs/training.md
+++ b/adapter_docs/training.md
@@ -56,7 +56,7 @@ model.set_active_adapters(task_name)
 
 The rest of the training procedure does not require any further changes in code.
 
-You can find the full version of the modified training script for GLUE at [run_glue_wh.py](https://github.com/Adapter-Hub/adapter-transformers/blob/master/examples/text-classification/run_glue_wh.py) in the `examples` folder of our repository.
+You can find the full version of the modified training script for GLUE at [run_glue_alt.py](https://github.com/Adapter-Hub/adapter-transformers/blob/master/examples/text-classification/run_glue_alt.py) in the `examples` folder of our repository.
 We also adapted various other example scripts (e.g. `run_glue.py`, `run_multiple_choice.py`, `run_squad.py`, ...) to support adapter training.
 
 To start adapter training on a GLUE task, you can run something similar to:
@@ -65,7 +65,7 @@ To start adapter training on a GLUE task, you can run something similar to:
 export GLUE_DIR=/path/to/glue
 export TASK_NAME=MNLI
 
-python run_glue_wh.py \
+python run_glue_alt.py \
   --model_name_or_path bert-base-cased \
   --task_name $TASK_NAME \
   --do_train \

--- a/adapter_docs/training.md
+++ b/adapter_docs/training.md
@@ -25,18 +25,24 @@ model = AutoModelWithHeads.from_pretrained(
 model.add_classification_head(data_args.task_name, num_labels=num_labels)
 ```
 
-The only main adaption we now have to make is to add a new adapter module:
+Compared to fine-tuning the full model, there is only one significant adaptation we have to make: adding a new adapter module and activating it.
 
 ```python
 # task adapter - only add if not existing
 if task_name not in model.config.adapters.adapter_list(AdapterType.text_task):
+    # resolve the adapter config
+    adapter_config = AdapterConfig.load(
+        adapter_args.adapter_config,
+        non_linearity=adapter_args.adapter_non_linearity,
+        reduction_factor=adapter_args.adapter_reduction_factor,
+    )
     # add a new adapter
     model.add_adapter(
         task_name,
         AdapterType.text_task
-        config=adapter_args.adapter_config
+        config=adapter_config
     )
-# enable adapter training
+# Enable adapter training
 model.train_adapter([task_name])
 ```
 
@@ -48,7 +54,7 @@ model.train_adapter([task_name])
     ``freeze_model(False)``.
 ```
 
-Besides this, we only have to make sure that the task adapter and prediction head are activated so that they are used in every forward pass:
+Besides this, we only have to make sure that the task adapter and prediction head are activated so that they are used in every forward pass. There are two ways to specify the adapter modules to be used. Either we can pass the parameter `adapter_names` in every call to `model.forward()`, or we can set the adapters to be used by default beforehand:
 
 ```python
 model.set_active_adapters(task_name)
@@ -101,12 +107,16 @@ described above, we add a language adapter module to an existing model training 
 script by adding the following code:
 
 ```python
-# language adapter - only add if not existing
+# check if language adapter already exists, otherwise add it
 if language not in model.config.adapters.adapter_list(AdapterType.text_lang):
-    model.set_adapter_config(AdapterType.text_lang, adapter_args.adapter_config)
-    model.add_adapter(language, AdapterType.text_lang)
-
-# enable adapter training
+    # resolve the adapter config
+    adapter_config = AdapterConfig.load(
+        adapter_args.adapter_config,
+        non_linearity=adapter_args.adapter_non_linearity,
+        reduction_factor=adapter_args.adapter_reduction_factor,
+    )
+    model.add_adapter(language, AdapterType.text_lang, config=adapter_config)
+# Freeze all model weights except of those of this adapter & use this adapter in every forward pass
 model.train_adapter([language])
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,33 +1,34 @@
 ## Examples
 
-Version 2.9 of `transformers` introduces a new [`Trainer`](https://github.com/huggingface/transformers/blob/master/src/transformers/trainer.py) class for PyTorch, and its equivalent [`TFTrainer`](https://github.com/huggingface/transformers/blob/master/src/transformers/trainer_tf.py) for TF 2.
+Version 2.9 of `transformers` introduces a new [`Trainer`](https://github.com/adapter-hub/adapter-transformers/blob/master/src/transformers/trainer.py) class for PyTorch, and its equivalent [`TFTrainer`](https://github.com/adapter-hub/adapter-transformers/blob/master/src/transformers/trainer_tf.py) for TF 2.
 Running the examples requires PyTorch 1.3.1+ or TensorFlow 2.0+.
 
 Here is the list of all our examples:
 - **grouped by task** (all official examples work for multiple models)
+- with information on whether support for training **Adapters** has been added to one of the example scripts (currently PyTorch only)
 - with information on whether they are **built on top of `Trainer`/`TFTrainer`** (if not, they still work, they might just lack some features),
 - whether they also include examples for **`pytorch-lightning`**, which is a great fully-featured, general-purpose training library for PyTorch,
-- links to **Colab notebooks** to walk through the scripts and run them easily,
-- links to **Cloud deployments** to be able to deploy large-scale trainings in the Cloud with little to no setup.
 
 This is still a work-in-progress – in particular documentation is still sparse – so please **contribute improvements/pull requests.**
+
+**Note**: For more information on training Adapters, please refer to the [Training section in the Adapter-Hub documentation](https://docs.adapterhub.ml/training).
 
 
 # The Big Table of Tasks
 
-| Task | Example datasets | Trainer support | TFTrainer support | pytorch-lightning | Colab
+| Task | Example datasets | Adapter support (pytorch) | Trainer support | TFTrainer support | pytorch-lightning
 |---|---|:---:|:---:|:---:|:---:|
-| [**`language-modeling`**](https://github.com/huggingface/transformers/tree/master/examples/language-modeling)       | Raw text        | ✅ | -  | -  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huggingface/blog/blob/master/notebooks/01_how_to_train.ipynb)
-| [**`text-classification`**](https://github.com/huggingface/transformers/tree/master/examples/text-classification)   | GLUE, XNLI      | ✅ | ✅ | ✅ | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huggingface/blog/blob/master/notebooks/trainer/01_text_classification.ipynb)
-| [**`token-classification`**](https://github.com/huggingface/transformers/tree/master/examples/token-classification) | CoNLL NER       | ✅ | ✅ | ✅ | -
-| [**`multiple-choice`**](https://github.com/huggingface/transformers/tree/master/examples/multiple-choice)           | SWAG, RACE, ARC | ✅ | ✅ | -  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ViktorAlm/notebooks/blob/master/MPC_GPU_Demo_for_TF_and_PT.ipynb)
-| [**`question-answering`**](https://github.com/huggingface/transformers/tree/master/examples/question-answering)     | SQuAD           | -  | ✅ | -  | -
-| [**`text-generation`**](https://github.com/huggingface/transformers/tree/master/examples/text-generation)     | -           | -  | - | -  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huggingface/blog/blob/master/notebooks/02_how_to_generate.ipynb)
-| [**`distillation`**](https://github.com/huggingface/transformers/tree/master/examples/distillation)       | All               | -  | -  | -  | -
-| [**`summarization`**](https://github.com/huggingface/transformers/tree/master/examples/summarization)     | CNN/Daily Mail    | -  | -  | -  | -
-| [**`translation`**](https://github.com/huggingface/transformers/tree/master/examples/translation)         | WMT               | -  | -  | -  | -
-| [**`bertology`**](https://github.com/huggingface/transformers/tree/master/examples/bertology)             | -                 | -  | -  | -  | -
-| [**`adversarial`**](https://github.com/huggingface/transformers/tree/master/examples/adversarial)         | HANS              | -  | -  | -  | -
+| [**`language-modeling`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/language-modeling)       | Raw text        | ✅ | ✅ | -  | -  
+| [**`text-classification`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/text-classification)   | GLUE, XNLI      | ✅ | ✅ | ✅ | ✅ 
+| [**`token-classification`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/token-classification) | CoNLL NER       | ✅ | ✅ | ✅ | ✅ 
+| [**`multiple-choice`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/multiple-choice)           | SWAG, RACE, ARC | ✅ | ✅ | ✅ | - 
+| [**`question-answering`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/question-answering)     | SQuAD           | ✅ | -  | ✅ | - 
+| [**`text-generation`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/text-generation)     | -           | - | -  | - | - 
+| [**`distillation`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/distillation)       | All               | - | -  | -  | - 
+| [**`summarization`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/summarization)     | CNN/Daily Mail    | - | -  | -  | - 
+| [**`translation`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/translation)         | WMT               | - | -  | -  | - 
+| [**`bertology`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/bertology)             | -                 | - | -  | -  | - 
+| [**`adversarial`**](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/adversarial)         | HANS              | - | -  | -  | - 
 
 
 <br>
@@ -39,7 +40,7 @@ To make sure you can successfully run the latest versions of the example scripts
 Execute the following steps in a new virtual environment:
 
 ```bash
-git clone https://github.com/huggingface/transformers
+git clone https://github.com/adapter-hub/adapter-transformers
 cd transformers
 pip install .
 pip install -r ./examples/requirements.txt
@@ -58,7 +59,7 @@ When using Tensorflow, TPUs are supported out of the box as a `tf.distribute.Str
 When using PyTorch, we support TPUs thanks to `pytorch/xla`. For more context and information on how to setup your TPU environment refer to Google's documentation and to the
 very detailed [pytorch/xla README](https://github.com/pytorch/xla/blob/master/README.md).
 
-In this repo, we provide a very simple launcher script named [xla_spawn.py](https://github.com/huggingface/transformers/tree/master/examples/xla_spawn.py) that lets you run our example scripts on multiple TPU cores without any boilerplate.
+In this repo, we provide a very simple launcher script named [xla_spawn.py](https://github.com/adapter-hub/adapter-transformers/tree/master/examples/xla_spawn.py) that lets you run our example scripts on multiple TPU cores without any boilerplate.
 Just pass a `--num_cores` flag to this script, then your regular training script with its arguments (this is similar to the `torch.distributed.launch` helper for torch.distributed).
 
 For example for `run_glue`:

--- a/examples/ner/.gitignore
+++ b/examples/ner/.gitignore
@@ -1,5 +1,0 @@
-*.tmp
-cached_*
-*.txt
-preprocess.*
-*.ps1

--- a/examples/question-answering/run_squad.py
+++ b/examples/question-answering/run_squad.py
@@ -825,7 +825,7 @@ def main():
 
     # Setup adapters
     if args.train_adapter:
-        task_name = "squad2.0" if args.version_2_with_negative else "squad"
+        task_name = "squad2" if args.version_2_with_negative else "squad1"
         # check if adapter already exists, otherwise add it
         if task_name not in model.config.adapters.adapter_list(AdapterType.text_task):
             # resolve the adapter config

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -97,8 +97,9 @@ class ExamplesTests(unittest.TestCase):
             --seed=42
             --max_seq_length=128
             --train_adapter
-            --adapter_config houlsby
-            --adapter_reduction_factor 12
+            --adapter_config=houlsby
+            --adapter_reduction_factor=12
+            --load_adapter=sts-b
             """.split()
         with patch.object(sys, "argv", testargs):
             result = run_glue.main()
@@ -150,6 +151,36 @@ class ExamplesTests(unittest.TestCase):
             --per_gpu_eval_batch_size=1
             --overwrite_output_dir
             --seed=42
+        """.split()
+        with patch.object(sys, "argv", testargs):
+            result = run_squad.main()
+            self.assertGreaterEqual(result["f1"], 30)
+            self.assertGreaterEqual(result["exact"], 30)
+
+    def test_run_squad_adapters(self):
+        stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
+
+        testargs = """
+            run_squad.py
+            --model_type=bert
+            --model_name_or_path=bert-base-uncased
+            --data_dir=./tests/fixtures/tests_samples/SQUAD
+            --model_name=bert-base-uncased
+            --output_dir=./tests/fixtures/tests_samples/temp_dir
+            --max_steps=10
+            --warmup_steps=2
+            --do_train
+            --do_eval
+            --version_2_with_negative
+            --learning_rate=2e-4
+            --per_gpu_train_batch_size=2
+            --per_gpu_eval_batch_size=1
+            --overwrite_output_dir
+            --seed=42
+            --train_adapter
+            --adapter_config=houlsby
+            --adapter_reduction_factor=12
         """.split()
         with patch.object(sys, "argv", testargs):
             result = run_squad.main()

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -76,6 +76,36 @@ class ExamplesTests(unittest.TestCase):
             for value in result.values():
                 self.assertGreaterEqual(value, 0.75)
 
+    def test_run_glue_adapters(self):
+        stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
+
+        testargs = """
+            run_glue.py
+            --model_name_or_path bert-base-uncased
+            --data_dir ./tests/fixtures/tests_samples/MRPC/
+            --task_name mrpc
+            --do_train
+            --do_eval
+            --output_dir ./tests/fixtures/tests_samples/temp_dir
+            --per_device_train_batch_size=2
+            --per_device_eval_batch_size=1
+            --learning_rate=1e-4
+            --max_steps=10
+            --warmup_steps=2
+            --overwrite_output_dir
+            --seed=42
+            --max_seq_length=128
+            --train_adapter
+            --adapter_config houlsby
+            --adapter_reduction_factor 12
+            """.split()
+        with patch.object(sys, "argv", testargs):
+            result = run_glue.main()
+            del result["eval_loss"]
+            for value in result.values():
+                self.assertGreaterEqual(value, 0.75)
+
     def test_run_language_modeling(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -98,8 +98,7 @@ class ExamplesTests(unittest.TestCase):
             --max_seq_length=128
             --train_adapter
             --adapter_config=houlsby
-            --adapter_reduction_factor=12
-            --load_adapter=sts-b
+            --load_adapter=qqp@ukp
             """.split()
         with patch.object(sys, "argv", testargs):
             result = run_glue.main()
@@ -168,7 +167,7 @@ class ExamplesTests(unittest.TestCase):
             --data_dir=./tests/fixtures/tests_samples/SQUAD
             --model_name=bert-base-uncased
             --output_dir=./tests/fixtures/tests_samples/temp_dir
-            --max_steps=10
+            --max_steps=20
             --warmup_steps=2
             --do_train
             --do_eval
@@ -180,7 +179,7 @@ class ExamplesTests(unittest.TestCase):
             --seed=42
             --train_adapter
             --adapter_config=houlsby
-            --adapter_reduction_factor=12
+            --adapter_reduction_factor=8
         """.split()
         with patch.object(sys, "argv", testargs):
             result = run_squad.main()

--- a/examples/text-classification/README.md
+++ b/examples/text-classification/README.md
@@ -85,6 +85,34 @@ CoLA, SST-2. The following section provides details on how to run half-precision
 said, there shouldn’t be any issues in running half-precision training with the remaining GLUE tasks as well,
 since the data processor for each task inherits from the base class DataProcessor.
 
+## Training Adapters in PyTorch
+
+Based on scripts `run_glue.py` and `run_glue_alt.py` (using model classes with flexible heads).
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Adapter-Hub/website/blob/master/app/static/notebooks/Adapter_Quickstart_Training.ipynb)
+
+By specifying a few additional, adapter-specific flags, you can easily switch from fine-tuning a full model to training Adapter modules on GLUE:
+
+```bash
+export GLUE_DIR=/path/to/glue
+export TASK_NAME=MRPC
+
+python run_glue_alt.py \
+  --model_type bert \
+  --model_name_or_path bert-base-cased \
+  --task_name $TASK_NAME \
+  --do_train \
+  --do_eval \
+  --data_dir $GLUE_DIR/$TASK_NAME \
+  --max_seq_length 128 \
+  --per_device_train_batch_size 32 \
+  --learning_rate 1e-4 \
+  --num_train_epochs 10.0 \
+  --output_dir /tmp/$TASK_NAME/ \
+  --train_adapter \
+  --adapter_config houlsby
+```
+
 ## Running on TPUs in PyTorch
 
 **Update**: read the more up-to-date [Running on TPUs](../README.md#running-on-tpus) in the main README.md instead.

--- a/examples/text-classification/run_fusion_glue.py
+++ b/examples/text-classification/run_fusion_glue.py
@@ -145,14 +145,7 @@ def main():
     )
 
     # Setup adapters
-    from transformers.adapter_config import AdapterType
-
-    base_model = getattr(model, model.base_model_prefix, model)
-    base_model.set_adapter_config(AdapterType.text_task, adapter_args.adapter_config)
-
     from transformers.adapter_config import PfeifferConfig
-
-    # from transformers.adapter_config import  HoulsbyConfig
 
     model.load_adapter(
         "sentiment/sst-2@ukp", "text_task", config=PfeifferConfig(), with_head=False, version="AdapterFusion"

--- a/examples/text-classification/run_fusion_glue.py
+++ b/examples/text-classification/run_fusion_glue.py
@@ -26,7 +26,7 @@ from typing import Dict, Optional
 
 import numpy as np
 
-from transformers import (  # setup_task_adapter_training,
+from transformers import (
     AdapterArguments,
     AutoConfig,
     AutoModelForSequenceClassification,
@@ -145,9 +145,6 @@ def main():
     )
 
     # Setup adapters
-    # task_name = data_args.task_name
-    # language = adapter_args.language
-    # setup_task_adapter_training(model, task_name, adapter_args)
     from transformers.adapter_config import AdapterType
 
     base_model = getattr(model, model.base_model_prefix, model)

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -27,7 +27,8 @@ from typing import Dict, Optional
 import numpy as np
 
 from transformers import (
-    AdapterArguments,
+    AdapterConfig,
+    AdapterType,
     AutoConfig,
     AutoModelForSequenceClassification,
     AutoTokenizer,
@@ -37,13 +38,13 @@ from transformers import (
 from transformers import GlueDataTrainingArguments as DataTrainingArguments
 from transformers import (
     HfArgumentParser,
+    MultiLingAdapterArguments,
     Trainer,
     TrainingArguments,
     glue_compute_metrics,
     glue_output_modes,
     glue_tasks_num_labels,
     set_seed,
-    setup_task_adapter_training,
 )
 
 
@@ -75,7 +76,7 @@ def main():
     # or by passing the --help flag to this script.
     # We now keep distinct sets of args, for a cleaner separation of concerns.
 
-    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments, AdapterArguments))
+    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments, MultiLingAdapterArguments))
 
     if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
         # If we pass only one argument to the script and it's the path to a json file,
@@ -146,9 +147,48 @@ def main():
     )
 
     # Setup adapters
-    task_name = data_args.task_name
-    language = adapter_args.language
-    setup_task_adapter_training(model, task_name, adapter_args)
+    if adapter_args.train_adapter:
+        task_name = data_args.task_name
+        # check if adapter already exists, otherwise add it
+        if task_name not in model.config.adapters.adapter_list(AdapterType.text_task):
+            # resolve the adapter config
+            adapter_config = AdapterConfig.load(
+                adapter_args.adapter_config,
+                non_linearity=adapter_args.adapter_non_linearity,
+                reduction_factor=adapter_args.adapter_reduction_factor,
+            )
+            # load a pre-trained from Hub if specified
+            if adapter_args.load_adapter:
+                model.load_adapter(
+                    adapter_args.load_adapter, AdapterType.text_task, config=adapter_config, load_as=task_name,
+                )
+            # otherwise, add a fresh adapter
+            else:
+                model.add_adapter(task_name, AdapterType.text_task, config=adapter_config)
+        # optionally load a pre-trained language adapter
+        if adapter_args.load_lang_adapter:
+            # resolve the language adapter config
+            lang_adapter_config = AdapterConfig.load(
+                adapter_args.lang_adapter_config,
+                non_linearity=adapter_args.lang_adapter_non_linearity,
+                reduction_factor=adapter_args.lang_adapter_reduction_factor,
+            )
+            # load the language adapter from Hub
+            lang_adapter_name = model.load_adapter(
+                adapter_args.load_lang_adapter,
+                AdapterType.text_lang,
+                config=lang_adapter_config,
+                load_as=adapter_args.language,
+            )
+        else:
+            lang_adapter_name = None
+        # Freeze all model weights except of those of this adapter
+        model.train_adapter([task_name])
+        # Set the adapters to be used in every forward pass
+        if lang_adapter_name:
+            model.set_active_adapters([lang_adapter_name, task_name])
+        else:
+            model.set_active_adapters([task_name])
 
     # Get datasets
     train_dataset = GlueDataset(data_args, tokenizer=tokenizer) if training_args.do_train else None
@@ -162,14 +202,6 @@ def main():
             preds = np.squeeze(p.predictions)
         return glue_compute_metrics(data_args.task_name, preds, p.label_ids)
 
-    if adapter_args.train_adapter:
-        if language:
-            adapter_names = [[language], [task_name]]
-        else:
-            adapter_names = [[task_name]]
-    else:
-        adapter_names = None
-
     # Initialize our Trainer
     trainer = Trainer(
         model=model,
@@ -179,7 +211,6 @@ def main():
         compute_metrics=compute_metrics,
         do_save_full_model=not adapter_args.train_adapter,
         do_save_adapters=adapter_args.train_adapter,
-        adapter_names=adapter_names,
     )
 
     # Training

--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -27,16 +27,17 @@ from seqeval.metrics import f1_score, precision_score, recall_score
 from torch import nn
 
 from transformers import (
-    AdapterArguments,
+    AdapterConfig,
+    AdapterType,
     AutoConfig,
     AutoModelForTokenClassification,
     AutoTokenizer,
     EvalPrediction,
     HfArgumentParser,
+    MultiLingAdapterArguments,
     Trainer,
     TrainingArguments,
     set_seed,
-    setup_task_adapter_training,
 )
 from utils_ner import NerDataset, Split, get_labels
 
@@ -96,7 +97,7 @@ def main():
     # or by passing the --help flag to this script.
     # We now keep distinct sets of args, for a cleaner separation of concerns.
 
-    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments, AdapterArguments))
+    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments, MultiLingAdapterArguments))
     if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
         # If we pass only one argument to the script and it's the path to a json file,
         # let's parse it to get our arguments.
@@ -167,16 +168,48 @@ def main():
     )
 
     # Setup adapters
-    task_name = "ner"
-    language = adapter_args.language
-    setup_task_adapter_training(model, task_name, adapter_args)
     if adapter_args.train_adapter:
-        if language:
-            adapter_names = [[language], [task_name]]
+        task_name = "ner"
+        # check if adapter already exists, otherwise add it
+        if task_name not in model.config.adapters.adapter_list(AdapterType.text_task):
+            # resolve the adapter config
+            adapter_config = AdapterConfig.load(
+                adapter_args.adapter_config,
+                non_linearity=adapter_args.adapter_non_linearity,
+                reduction_factor=adapter_args.adapter_reduction_factor,
+            )
+            # load a pre-trained from Hub if specified
+            if adapter_args.load_adapter:
+                model.load_adapter(
+                    adapter_args.load_adapter, AdapterType.text_task, config=adapter_config, load_as=task_name,
+                )
+            # otherwise, add a fresh adapter
+            else:
+                model.add_adapter(task_name, AdapterType.text_task, config=adapter_config)
+        # optionally load a pre-trained language adapter
+        if adapter_args.load_lang_adapter:
+            # resolve the language adapter config
+            lang_adapter_config = AdapterConfig.load(
+                adapter_args.lang_adapter_config,
+                non_linearity=adapter_args.lang_adapter_non_linearity,
+                reduction_factor=adapter_args.lang_adapter_reduction_factor,
+            )
+            # load the language adapter from Hub
+            lang_adapter_name = model.load_adapter(
+                adapter_args.load_lang_adapter,
+                AdapterType.text_lang,
+                config=lang_adapter_config,
+                load_as=adapter_args.language,
+            )
         else:
-            adapter_names = [[task_name]]
-    else:
-        adapter_names = None
+            lang_adapter_name = None
+        # Freeze all model weights except of those of this adapter
+        model.train_adapter([task_name])
+        # Set the adapters to be used in every forward pass
+        if lang_adapter_name:
+            model.set_active_adapters([lang_adapter_name, task_name])
+        else:
+            model.set_active_adapters([task_name])
 
     # Get datasets
     train_dataset = (
@@ -239,7 +272,6 @@ def main():
         compute_metrics=compute_metrics,
         do_save_full_model=not adapter_args.train_adapter,
         do_save_adapters=adapter_args.train_adapter,
-        adapter_names=adapter_names,
     )
 
     # Training

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -150,7 +150,7 @@ if is_sklearn_available():
 
 # Adapters
 if is_torch_available():
-    from .adapter_training import AdapterArguments, MultiLingAdapterArguments, setup_task_adapter_training
+    from .adapter_training import AdapterArguments, MultiLingAdapterArguments
     from .adapter_model_mixin import (
         WeightsLoaderHelper,
         WeightsLoader,

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -150,7 +150,7 @@ if is_sklearn_available():
 
 # Adapters
 if is_torch_available():
-    from .adapter_training import AdapterArguments, setup_task_adapter_training
+    from .adapter_training import AdapterArguments, MultiLingAdapterArguments, setup_task_adapter_training
     from .adapter_model_mixin import (
         WeightsLoaderHelper,
         WeightsLoader,

--- a/src/transformers/adapter_config.py
+++ b/src/transformers/adapter_config.py
@@ -100,6 +100,8 @@ class AdapterConfig(Mapping):
         Returns:
             dict: The resolved adapter configuration dictionary.
         """
+        if not config:
+            return None
         # if force_download is set, skip the local map
         if download_kwargs and download_kwargs.get("force_download", False):
             local_map = None
@@ -112,7 +114,7 @@ class AdapterConfig(Mapping):
         # convert back to dict to allow attr overrides
         if isinstance(config_dict, AdapterConfig):
             config_dict = config_dict.to_dict()
-        config_dict.update(kwargs)
+        config_dict.update((k, v) for k, v in kwargs.items() if v is not None)
         return AdapterConfig.from_dict(config_dict)
 
 

--- a/src/transformers/adapter_training.py
+++ b/src/transformers/adapter_training.py
@@ -1,9 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
-from .adapter_bert import BertModelHeadsMixin
-from .adapter_config import AdapterConfig, AdapterType
-
 
 @dataclass
 class AdapterArguments:

--- a/src/transformers/adapter_training.py
+++ b/src/transformers/adapter_training.py
@@ -11,19 +11,39 @@ class AdapterArguments:
     The subset of arguments related to adapter training.
     """
 
-    train_adapter: bool = field(
-        default=False, metadata={"help": "Train a text task adapter instead of the full model."}
+    train_adapter: bool = field(default=False, metadata={"help": "Train an adapter instead of the full model."})
+    load_adapter: Optional[str] = field(
+        default="", metadata={"help": "Pre-trained adapter module to be loaded from Hub."}
     )
-    load_task_adapter: Optional[str] = field(
-        default="", metadata={"help": "Pre-trained task adapter to be loaded for further training."}
+    adapter_config: Optional[str] = field(
+        default="pfeiffer", metadata={"help": "Adapter configuration. Either an identifier or a path to a file."}
     )
+    adapter_non_linearity: Optional[str] = field(
+        default=None, metadata={"help": "Override the non-linearity of the adapter configuration."}
+    )
+    adapter_reduction_factor: Optional[str] = field(
+        default=None, metadata={"help": "Override the reduction factor of the adapter configuration."}
+    )
+    language: Optional[str] = field(default=None, metadata={"help": "The training language, e.g. 'en' for English."})
+
+
+@dataclass
+class MultiLingAdapterArguments(AdapterArguments):
+    """
+    Arguemnts related to adapter training, extended by arguments for multilingual setups.
+    """
+
     load_lang_adapter: Optional[str] = field(
-        default=None, metadata={"help": "Pre-trained language adapter to be loaded."}
+        default=None, metadata={"help": "Pre-trained language adapter module to be loaded from Hub."}
     )
-    adapter_config: Optional[str] = field(default="pfeiffer", metadata={"help": "Adapter configuration."})
-    lang_adapter_config: Optional[str] = field(default=None, metadata={"help": "Language adapter configuration."})
-    language: Optional[str] = field(
-        default=None, metadata={"help": "The adapter name of the loaded language adapter, e.g. 'en' for english."}
+    lang_adapter_config: Optional[str] = field(
+        default=None, metadata={"help": "Language adapter configuration. Either an identifier or a path to a file."}
+    )
+    lang_adapter_non_linearity: Optional[str] = field(
+        default=None, metadata={"help": "Override the non-linearity of the language adapter configuration."}
+    )
+    lang_adapter_reduction_factor: Optional[str] = field(
+        default=None, metadata={"help": "Override the reduction factor of the language adapter configuration."}
     )
 
 

--- a/src/transformers/adapter_training.py
+++ b/src/transformers/adapter_training.py
@@ -21,7 +21,7 @@ class AdapterArguments:
     adapter_non_linearity: Optional[str] = field(
         default=None, metadata={"help": "Override the non-linearity of the adapter configuration."}
     )
-    adapter_reduction_factor: Optional[str] = field(
+    adapter_reduction_factor: Optional[int] = field(
         default=None, metadata={"help": "Override the reduction factor of the adapter configuration."}
     )
     language: Optional[str] = field(default=None, metadata={"help": "The training language, e.g. 'en' for English."})

--- a/src/transformers/adapter_training.py
+++ b/src/transformers/adapter_training.py
@@ -42,49 +42,6 @@ class MultiLingAdapterArguments(AdapterArguments):
     lang_adapter_non_linearity: Optional[str] = field(
         default=None, metadata={"help": "Override the non-linearity of the language adapter configuration."}
     )
-    lang_adapter_reduction_factor: Optional[str] = field(
+    lang_adapter_reduction_factor: Optional[int] = field(
         default=None, metadata={"help": "Override the reduction factor of the language adapter configuration."}
     )
-
-
-def setup_task_adapter_training(model, task_name: str, adapter_args: AdapterArguments):
-    """Sets up task adapter training for a given pre-trained model.
-
-    Args:
-        model (PretrainedModel): The model for which to set up task adapter training.
-        task_name (str): The name of the task to train.
-        adapter_args (AdapterArguments): Adapter traininf arguments.
-    """
-    language = adapter_args.load_lang_adapter
-    if adapter_args.train_adapter:
-        # task adapter - only add if not existing
-        if task_name not in model.config.adapters.adapter_list(AdapterType.text_task):
-            # load a pre-trained adapter for fine-tuning if specified
-            if adapter_args.load_task_adapter:
-                model.load_adapter(
-                    adapter_args.load_task_adapter,
-                    AdapterType.text_task,
-                    config=adapter_args.adapter_config,
-                    load_as=task_name,
-                )
-            # otherwise, add a new adapter
-            else:
-                model.add_adapter(task_name, AdapterType.text_task, config=adapter_args.adapter_config)
-        # language adapter - only add if not existing
-        if language and language not in model.config.adapters.adapter_list(AdapterType.text_lang):
-            lconfig_string = adapter_args.lang_adapter_config or adapter_args.adapter_config
-            # TODO support different non_linearity & reduction_factor
-            lconfig = AdapterConfig.load(lconfig_string, non_linearity="gelu", reduction_factor=2)
-
-            model.load_adapter(
-                adapter_args.load_lang_adapter, AdapterType.text_lang, config=lconfig, load_as=adapter_args.language
-            )
-        # enable adapter training
-        model.train_adapter([task_name])
-    # set adapters as default if possible
-    if isinstance(model, BertModelHeadsMixin):
-        adapter_names = []
-        if language:
-            adapter_names.append([language])
-        adapter_names.append([task_name])
-        model.set_active_adapters(adapter_names)


### PR DESCRIPTION
Changes in this PR:
- Cleanup adapter setup in example scripts (e.g. switch to `set_active_adapters()`) & remove "magic" setup method
- Add CLI arguments for changing reduction factor & non-linearity in adapter config
- Add two small tests for example scripts using adapter training
- Mention adapter training in README example scripts (e.g. "The Big Table of Tasks")
- Minor improvements in docs (addressing https://github.com/Adapter-Hub/adapter-transformers/issues/26#issuecomment-677938162)
- Fixes #33. Supersedes #34.