### PR TITLE
Hotfix for adapter config saving/loading

### DIFF
--- a/src/transformers/adapter_config.py
+++ b/src/transformers/adapter_config.py
@@ -189,8 +189,12 @@ class ModelAdaptersConfig:
                 config = self.config_map.get(config_name, None)
             else:
                 config = ADAPTER_CONFIG_MAP.get(config_name, None)
-            if not config:
+            if not config and adapter_type in self.config_map:
                 config = self.config_map[adapter_type]
+            elif (
+                not config
+            ):  # If no config is specified via config_name or adapter_type, we just use the global default
+                config = DEFAULT_ADAPTER_CONFIG
             if isinstance(config, str):
                 config = ADAPTER_CONFIG_MAP[config]
         else:
@@ -203,6 +207,9 @@ class ModelAdaptersConfig:
     def add(self, adapter_name: str, adapter_type: AdapterType, config: Optional[Union[str, dict]] = None):
         if adapter_name in self.adapters:
             raise ValueError(f"An adapter with the name '{adapter_name}' has already been added.")
+        if config is None and adapter_type not in self.config_map:
+            # if config is not specified & no per-type default is set, manually set global default
+            config = DEFAULT_ADAPTER_CONFIG
         config_name = config
         if isinstance(config, str):
             if config not in ADAPTER_CONFIG_MAP and config not in self.config_map:
@@ -257,6 +264,7 @@ class ModelAdaptersConfig:
     def to_dict(self):
         output_dict = {}
         output_dict["adapters"] = copy.deepcopy(self.adapters)
+        output_dict["config_map"] = copy.deepcopy(self.config_map)
         return output_dict
 
 

--- a/tests/test_adapter_loading.py
+++ b/tests/test_adapter_loading.py
@@ -83,6 +83,30 @@ class AdapterModelTest(unittest.TestCase):
                     self.assertEqual(len(output1), len(output2))
                     self.assertTrue(torch.equal(output1[0], output2[0]))
 
+    def test_load_full_model(self):
+        for model_class in self.model_classes:
+            model_config = model_class.config_class
+            model1 = model_class(model_config())
+            model1.eval()
+
+            for name, adapter_type in AdapterType.__members__.items():
+                with self.subTest(model_class=model_class, adapter_type=name):
+                    model1.add_adapter(name, adapter_type)
+                    with tempfile.TemporaryDirectory() as temp_dir:
+                        model1.save_pretrained(temp_dir)
+
+                        model2 = model_class.from_pretrained(temp_dir)
+
+                    # check if adapter was correctly loaded
+                    self.assertTrue(name in model2.config.adapters.adapter_list(adapter_type))
+
+                    # check equal output
+                    in_data = ids_tensor((1, 128), 1000)
+                    output1 = model1(in_data, adapter_names=[name])
+                    output2 = model2(in_data, adapter_names=[name])
+                    self.assertEqual(len(output1), len(output2))
+                    self.assertTrue(torch.equal(output1[0], output2[0]))
+
     def test_model_config_serialization(self):
         """PretrainedConfigurations should not raise an Exception when serializing the config dict
 


### PR DESCRIPTION
#42 introduced a severe bug when saving & reloading a full model with adapters (ModelAdaptersConfig is not serialized/ deserialized correctly)