### PR TITLE
Fix module registration of new prediction head modules

### DIFF
--- a/src/transformers/adapter_heads.py
+++ b/src/transformers/adapter_heads.py
@@ -11,17 +11,14 @@ from .modeling_outputs import (
 )
 
 
-class PredictionHead(nn.Module):
+# Let this class inherit from nn.Sequential to provide iterable access as before
+class PredictionHead(nn.Sequential):
     def __init__(self, name):
         super().__init__()
-        self.config = None
-        self.head = None
+        self.config = {}
         self.name = name
 
-    def build(
-        self,
-        model,
-    ):  # _init_weights):
+    def build(self, model):
         model_config = model.config
         pred_head = []
         for l in range(self.config["layers"]):
@@ -34,23 +31,11 @@ class PredictionHead(nn.Module):
                     pred_head.append(nn.Linear(model_config.hidden_size, self.config["num_labels"]))
                 else:  # used for multiple_choice head
                     pred_head.append(nn.Linear(model_config.hidden_size, 1))
-        self.head = nn.Sequential(*pred_head)
+        for i, module in enumerate(pred_head):
+            self.add_module(str(i), module)
 
-        self.head.apply(model._init_weights)
+        self.apply(model._init_weights)
         self.train(model.training)  # make sure training mode is consistent
-
-    def forward(self, outputs, attention_mask, return_dict, **kwarg):
-        raise NotImplementedError("Use a Prediction Head that inherits from this class")
-
-    def save_head(self, path):
-        torch.save(self, path)
-
-    @staticmethod
-    def load_head(self, path, load_as):
-        head = torch.load(path)
-        if load_as:
-            head.name = load_as
-        return head
 
 
 class ClassificationHead(PredictionHead):
@@ -67,7 +52,7 @@ class ClassificationHead(PredictionHead):
 
     def forward(self, outputs, attention_mask, return_dict, **kwargs):
 
-        logits = self.head(outputs[0][:, 0])
+        logits = super().forward(outputs[0][:, 0])
         loss = None
         labels = kwargs.pop("labels", None)
         if labels is not None:
@@ -106,7 +91,7 @@ class MultiLabelClassificationHead(PredictionHead):
         self.build(model)
 
     def forward(self, outputs, attention_mask, return_dict, **kwargs):
-        logits = self.head(outputs[0][:, 0])
+        logits = super().forward(outputs[0][:, 0])
         loss = None
         labels = kwargs.pop("labels", None)
         if labels is not None:
@@ -142,7 +127,7 @@ class MultipleChoiceHead(PredictionHead):
         self.build(model)
 
     def forward(self, outputs, attention_mask, return_dict, **kwargs):
-        logits = self.head(outputs[0][:, 0])
+        logits = super().forward(outputs[0][:, 0])
         logits = logits.view(-1, self.config["num_choices"])
         loss = None
         labels = kwargs.pop("labels", None)
@@ -177,7 +162,7 @@ class TaggingHead(PredictionHead):
         self.build(model)
 
     def forward(self, outputs, attention_mask, return_dict, **kwargs):
-        logits = self.head(outputs[0])
+        logits = super().forward(outputs[0])
         loss = None
 
         labels = kwargs.pop("labels", None)
@@ -222,15 +207,11 @@ class QuestionAnsweringHead(PredictionHead):
 
     def forward(self, outputs, attention_mask, return_dict, **kwargs):
         sequence_output = outputs[0]
-        logits = self.heads[self.name](sequence_output)
+        logits = super().forward(sequence_output)
         start_logits, end_logits = logits.split(1, dim=-1)
         start_logits = start_logits.squeeze(-1)
         end_logits = end_logits.squeeze(-1)
 
-        outputs = (
-            start_logits,
-            end_logits,
-        ) + outputs[2:]
         start_positions = kwargs.pop("start_positions", None)
         end_positions = kwargs.pop("end_positions", None)
         total_loss = None
@@ -248,7 +229,6 @@ class QuestionAnsweringHead(PredictionHead):
             start_loss = loss_fct(start_logits, start_positions)
             end_loss = loss_fct(end_logits, end_positions)
             total_loss = (start_loss + end_loss) / 2
-            outputs = (total_loss,) + outputs
 
         if return_dict:
             return QuestionAnsweringModelOutput(
@@ -259,4 +239,10 @@ class QuestionAnsweringHead(PredictionHead):
                 attentions=outputs.attentions,
             )
         else:
+            outputs = (
+                start_logits,
+                end_logits,
+            ) + outputs[2:]
+            if total_loss is not None:
+                outputs = (total_loss,) + outputs
             return outputs

--- a/src/transformers/adapter_heads.py
+++ b/src/transformers/adapter_heads.py
@@ -37,6 +37,7 @@ class PredictionHead(nn.Module):
         self.head = nn.Sequential(*pred_head)
 
         self.head.apply(model._init_weights)
+        self.train(model.training)  # make sure training mode is consistent
 
     def forward(self, outputs, attention_mask, return_dict, **kwarg):
         raise NotImplementedError("Use a Prediction Head that inherits from this class")

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -21,8 +21,6 @@ import json
 import os
 from typing import Any, Dict, Tuple
 
-from transformers.adapter_heads import PredictionHead
-
 from .adapter_utils import DataclassJSONEncoder
 from .file_utils import CONFIG_NAME, cached_path, hf_bucket_url, is_remote_url
 from .utils import logging
@@ -526,10 +524,6 @@ class PretrainedConfig(object):
             output["model_type"] = self.__class__.model_type
         if hasattr(self, "adapters") and not isinstance(output["adapters"], dict):
             output["adapters"] = self.adapters.to_dict()
-        if "prediction_heads" in output.keys():
-            for head in output["prediction_heads"].keys():
-                if isinstance(output["prediction_heads"][head], PredictionHead):
-                    output["prediction_heads"][head] = output["prediction_heads"][head].config
         if "custom_heads" in output.keys():
             del output["custom_heads"]
         return output

--- a/tests/test_adapter_common.py
+++ b/tests/test_adapter_common.py
@@ -175,6 +175,14 @@ class PredictionHeadModelTest(unittest.TestCase):
                 model1.add_tagging_head("dummy")
                 self.run_prediction_head_test(model1, model2, "dummy", output_shape=(1, 128, 2))
 
+    def test_qa_head(self):
+        for model_class in self.model_classes:
+            model1, model2 = create_twin_models(model_class)
+
+            with self.subTest(model_class=model_class.__name__):
+                model1.add_qa_head("dummy")
+                self.run_prediction_head_test(model1, model2, "dummy", output_shape=(1, 128))
+
     def test_adapter_with_head(self):
         for model_class in self.model_classes:
             model1, model2 = create_twin_models(model_class)

--- a/tests/test_adapter_common.py
+++ b/tests/test_adapter_common.py
@@ -129,13 +129,17 @@ class PredictionHeadModelTest(unittest.TestCase):
     model_classes = [BertModelWithHeads, RobertaModelWithHeads, DistilBertModelWithHeads]
 
     def run_prediction_head_test(self, model, compare_model, head_name, input_shape=(1, 128), output_shape=(1, 2)):
+        # first, check if the head is actually correctly registered as part of the pt module
+        self.assertTrue(f"heads.{head_name}" in dict(model.named_modules()))
+
+        # save & reload
         with tempfile.TemporaryDirectory() as temp_dir:
             model.save_head(temp_dir, head_name)
 
             compare_model.load_head(temp_dir)
 
         # check if adapter was correctly loaded
-        self.assertTrue(head_name in compare_model.config.prediction_heads)
+        self.assertTrue(head_name in compare_model.heads)
 
         in_data = ids_tensor(input_shape, 1000)
         model.set_active_adapters(head_name)
@@ -228,7 +232,7 @@ class PredictionHeadModelTest(unittest.TestCase):
                     model.save_pretrained(temp_dir)
                     # reload
                     model = model_class.from_pretrained(temp_dir)
-                self.assertIn("dummy", model.config.prediction_heads)
+                self.assertIn("dummy", model.heads)
                 self.assertDictEqual(true_config, model.get_prediction_heads_config())
 
 

--- a/tests/test_adapter_custom_head.py
+++ b/tests/test_adapter_custom_head.py
@@ -15,7 +15,7 @@ class CustomHead(PredictionHead):
         self.build(model=model)
 
     def forward(self, outputs, attention_mask, return_dict, **kwargs):
-        logits = self.head(outputs[0])
+        logits = super().forward(outputs[0])
         outputs = (logits,) + outputs[2:]
         return outputs
 

--- a/tests/test_adapter_custom_head.py
+++ b/tests/test_adapter_custom_head.py
@@ -66,7 +66,7 @@ class AdapterCustomHeadTest(unittest.TestCase):
         output1 = model1(in_data)
         output2 = model2(in_data)
         self.assertEqual(output1[0].size(), output2[0].size())
-        state1 = model1.config.prediction_heads["custom_head"].state_dict()
-        state2 = model2.config.prediction_heads["custom_head"].state_dict()
+        state1 = model1.heads["custom_head"].state_dict()
+        state2 = model2.heads["custom_head"].state_dict()
         for ((k1, v1), (k2, v2)) in zip(state1.items(), state2.items()):
             self.assertTrue(torch.equal(v1, v2))


### PR DESCRIPTION
Follow-up to #88. Closes #100.

Currently, the new prediction head modules (`PredictionHead` class) are not correctly registered as submodules of the model by PyTorch as they're not attributes of the model class (which is a PT module) but of the model config (which is not a PT module). This leads to multiple errors (e.g. not part of `state_dict`, ignored when setting train/ eval, moving to GPU (#100)).

Changed the implementation to put head modules into the `heads` module dict in the model class again. `config.prediction_heads` only holds references to the config dicts. Also removed some now unnecessary logic in `adapter_model_mixin.py`.

Added a check for this in prediction heads test cases: https://github.com/calpt/adapter-transformers/blob/3f6c40ca15926e7610aae1904f9b5792851e245d/tests/test_adapter_common.py#L132-L133.

**Edit:**
Added fixes for related issues:
- prediction head for QA (covered by new test in `test_adapter_common.py`)
- restored backwards compability to heads on the Hub by extending PredictionHead from nn.Sequential (covered in `test_adapter_hub.py`)
- cleaned up unused methods