### PR TITLE
Hotfixes for DistilBERT adapter & AdapterFusion implementations

### DIFF
--- a/src/transformers/adapter_bert.py
+++ b/src/transformers/adapter_bert.py
@@ -536,6 +536,21 @@ class BertModelAdaptersMixin(InvertibleAdaptersMixin, ModelAdaptersMixin):
     def _add_fusion_layer(self, adapter_names):
         self.encoder.add_fusion_layer(adapter_names)
 
+    def get_fusion_regularization_loss(self):
+        reg_loss = 0.0
+        target = torch.zeros((self.config.hidden_size, self.config.hidden_size)).fill_diagonal_(1.0).to(self.device)
+        for _, v in self.encoder.layer._modules.items():
+
+            for _, layer_fusion in v.output.adapter_fusion_layer.items():
+                if hasattr(layer_fusion, "value"):
+                    reg_loss += 0.01 * (target - layer_fusion.value.weight).pow(2).sum()
+
+            for _, layer_fusion in v.attention.output.adapter_fusion_layer.items():
+                if hasattr(layer_fusion, "value"):
+                    reg_loss += 0.01 * (target - layer_fusion.value.weight).pow(2).sum()
+
+        return reg_loss
+
 
 class BertModelHeadsMixin(ModelWithHeadsAdaptersMixin):
     """Adds heads to a Bert-based module."""

--- a/src/transformers/adapter_modeling.py
+++ b/src/transformers/adapter_modeling.py
@@ -235,29 +235,6 @@ class BertFusion(nn.Module):
         return context_layer
 
 
-def get_fusion_regularization_loss(model):
-    if hasattr(model, "base_model"):
-        model = model.base_model
-    elif hasattr(model, "encoder"):
-        pass
-    else:
-        raise Exception("Model not passed correctly, please pass a transformer model with an encoder")
-
-    reg_loss = 0.0
-    target = torch.zeros((model.config.hidden_size, model.config.hidden_size)).fill_diagonal_(1.0).to(model.device)
-    for k, v in model.encoder.layer._modules.items():
-
-        for _, layer_fusion in v.output.adapter_fusion_layer.items():
-            if hasattr(layer_fusion, "value"):
-                reg_loss += 0.01 * (target - layer_fusion.value.weight).pow(2).sum()
-
-        for _, layer_fusion in v.attention.output.adapter_fusion_layer.items():
-            if hasattr(layer_fusion, "value"):
-                reg_loss += 0.01 * (target - layer_fusion.value.weight).pow(2).sum()
-
-    return reg_loss
-
-
 # Invertible Adapters
 
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -51,7 +51,6 @@ from torch.utils.data.dataset import Dataset
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import RandomSampler, SequentialSampler
 
-from .adapter_modeling import get_fusion_regularization_loss
 from .data.data_collator import DataCollator, DataCollatorWithPadding, default_data_collator
 from .file_utils import WEIGHTS_NAME, is_datasets_available, is_in_notebook, is_torch_tpu_available
 from .modeling_auto import MODEL_FOR_QUESTION_ANSWERING_MAPPING
@@ -798,7 +797,7 @@ class Trainer:
                         hasattr(self.model.config, "adapter_fusion")
                         and self.model.config.adapter_fusion["regularization"]
                     ):
-                        fusion_reg_loss = get_fusion_regularization_loss(self.model)
+                        fusion_reg_loss = self.model.base_model.get_fusion_regularization_loss()
                         fusion_reg_loss.backward()
 
                     if self.args.fp16 and _use_native_amp:

--- a/tests/test_adapter_training.py
+++ b/tests/test_adapter_training.py
@@ -22,7 +22,7 @@ def filter_parameters(model, filter_string):
 @require_torch
 class AdapterTrainingTest(unittest.TestCase):
 
-    model_names = ["bert-base-uncased"]
+    model_names = ["bert-base-uncased", "distilbert-base-uncased"]
 
     def test_train_single_adapter(self):
         for model_name in self.model_names:


### PR DESCRIPTION
This PR fixes the following for DistilBERT:

- AdapterFusion regularization by moving the fusion regularization loss implementation to the model classes
- the layer norm in the Transformer block: The layer norm module is part of the TransformerBlock class (different from BERT implementation), however we need to access it from the adapter module, which is a _submodule_ of the former. Therefore, we need some sort of reference in the submodule. The previous implementation didn't work as it copied the layer norm weights.