### PR TITLE
 Drop pooler output from flex head output for consistency between BERT & DistilBERT

### DIFF
--- a/src/transformers/adapter_heads.py
+++ b/src/transformers/adapter_heads.py
@@ -72,7 +72,7 @@ class ClassificationHead(PredictionHead):
                 attentions=outputs.attentions,
             )
         else:
-            outputs = (logits,) + outputs[2:]
+            outputs = (logits,) + outputs[1:]
             if labels is not None:
                 outputs = (loss,) + outputs
             return outputs
@@ -108,7 +108,7 @@ class MultiLabelClassificationHead(PredictionHead):
                 attentions=outputs.attentions,
             )
         else:
-            outputs = (logits,) + outputs[2:]
+            outputs = (logits,) + outputs[1:]
             if labels is not None:
                 outputs = (loss,) + outputs
             return outputs
@@ -143,7 +143,7 @@ class MultipleChoiceHead(PredictionHead):
                 attentions=outputs.attentions,
             )
         else:
-            outputs = (logits,) + outputs[2:]
+            outputs = (logits,) + outputs[1:]
             if labels is not None:
                 outputs = (loss,) + outputs
             return outputs
@@ -187,7 +187,7 @@ class TaggingHead(PredictionHead):
                 attentions=outputs.attentions,
             )
         else:
-            outputs = (logits,) + outputs[2:]
+            outputs = (logits,) + outputs[1:]
             if labels is not None:
                 outputs = (loss,) + outputs
             return outputs
@@ -242,7 +242,7 @@ class QuestionAnsweringHead(PredictionHead):
             outputs = (
                 start_logits,
                 end_logits,
-            ) + outputs[2:]
+            ) + outputs[1:]
             if total_loss is not None:
                 outputs = (total_loss,) + outputs
             return outputs

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -804,12 +804,20 @@ class RobertaModelWithHeads(BertModelHeadsMixin, RobertaPreTrainedModel):
             adapter_names=adapter_names,
             return_dict=return_dict,
         )
+        # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
+        if not return_dict:
+            head_inputs = (outputs[0],) + outputs[2:]
+        else:
+            head_inputs = outputs
 
-        outputs = self.forward_head(
-            outputs, head_name=head, attention_mask=attention_mask, return_dict=return_dict, **kwargs
+        head_outputs = self.forward_head(
+            head_inputs, head_name=head, attention_mask=attention_mask, return_dict=return_dict, **kwargs
         )
+        # plug pooler outputs back in
+        if not return_dict:
+            head_outputs = (head_outputs[0], outputs[1]) + head_outputs[1:]
 
-        return outputs
+        return head_outputs
 
 
 @add_start_docstrings(


### PR DESCRIPTION
Follow-up of #101 (merge that first).

BERT & RoBERTa models have a pooler module built-in (used for HF prediction heads, but not flex heads). The output of the pooler is returned by the forward() call by default. As other models (e.g. DistilBERT) don't have this pooler, remove it from the input to the prediction head modules for consistent input handling and plug in back afterwards.