### PR TITLE
Fixed passing labels to model in adapter training notebook

### DIFF
--- a/notebooks/01_Adapter_Training.ipynb
+++ b/notebooks/01_Adapter_Training.ipynb
@@ -15,7 +15,7 @@
     "accelerator": "GPU",
     "widgets": {
       "application/vnd.jupyter.widget-state+json": {
-        "01d575495f3449f1bb900454d851de7c": {
+        "c3aa99f89b76454c96a862454a359f6b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -27,15 +27,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_3cbbb1f26fff4fa4960886ecd9ddf7a5",
+            "layout": "IPY_MODEL_7487c6cc822d491597a3aada5af8e454",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_b078d98497a94753827930a620a05824",
-              "IPY_MODEL_6b8b58c14c4246d4a5f062ead85b9c2f"
+              "IPY_MODEL_c434f4813daf4dd699c553d2a6736e00",
+              "IPY_MODEL_f9f50a85c48b4d4786ac16836ef0e083"
             ]
           }
         },
-        "3cbbb1f26fff4fa4960886ecd9ddf7a5": {
+        "7487c6cc822d491597a3aada5af8e454": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -86,12 +86,12 @@
             "left": null
           }
         },
-        "b078d98497a94753827930a620a05824": {
+        "c434f4813daf4dd699c553d2a6736e00": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_ff436e4a2cc04b2680fc413480965595",
+            "style": "IPY_MODEL_cb1ee710a1344fe8b0c817249fb51e3d",
             "_dom_classes": [],
             "description": "Downloading: ",
             "_model_name": "FloatProgressModel",
@@ -106,30 +106,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_13f6df5e854e4b9e99e727bccdeb3475"
+            "layout": "IPY_MODEL_adb199dacb9c4881be7ae6ffdd665b54"
           }
         },
-        "6b8b58c14c4246d4a5f062ead85b9c2f": {
+        "f9f50a85c48b4d4786ac16836ef0e083": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_93b0ddfe6cde4d21980f00cdfb23fe18",
+            "style": "IPY_MODEL_643c34677a93499fa233e5f52649b0e0",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 5.04k/? [00:01&lt;00:00, 4.28kB/s]",
+            "value": " 5.04k/? [00:00&lt;00:00, 5.34kB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_a3ada4e3a4ff4f85b4de16e79788fa8b"
+            "layout": "IPY_MODEL_94832fd6f4f7419bac117598f804d1c6"
           }
         },
-        "ff436e4a2cc04b2680fc413480965595": {
+        "cb1ee710a1344fe8b0c817249fb51e3d": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -144,7 +144,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "13f6df5e854e4b9e99e727bccdeb3475": {
+        "adb199dacb9c4881be7ae6ffdd665b54": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -195,7 +195,7 @@
             "left": null
           }
         },
-        "93b0ddfe6cde4d21980f00cdfb23fe18": {
+        "643c34677a93499fa233e5f52649b0e0": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -209,7 +209,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "a3ada4e3a4ff4f85b4de16e79788fa8b": {
+        "94832fd6f4f7419bac117598f804d1c6": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -260,7 +260,7 @@
             "left": null
           }
         },
-        "cc11d16e71a44c18b6428d1a2b63a235": {
+        "601e07e7e60e440aab0792c52c4e59eb": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -272,15 +272,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_a4269ca6b9454424b58a8e4e7e74db0f",
+            "layout": "IPY_MODEL_c472912011a6462088eeeb2baba50bf0",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_bd322bd508ca4df788669b8dd8fd8f0f",
-              "IPY_MODEL_53ec6e9b981644afaf59bd79ff9b3139"
+              "IPY_MODEL_075ff4547bcd44e48ec9255ade034dcf",
+              "IPY_MODEL_f70900ce8da44d7b98ad436057e61a14"
             ]
           }
         },
-        "a4269ca6b9454424b58a8e4e7e74db0f": {
+        "c472912011a6462088eeeb2baba50bf0": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -331,12 +331,12 @@
             "left": null
           }
         },
-        "bd322bd508ca4df788669b8dd8fd8f0f": {
+        "075ff4547bcd44e48ec9255ade034dcf": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_202f50faeb03486cb69ed79764051928",
+            "style": "IPY_MODEL_7adefdefdb0d4e3c89dea3f94355a22a",
             "_dom_classes": [],
             "description": "Downloading: ",
             "_model_name": "FloatProgressModel",
@@ -351,30 +351,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_d2f27559128a43529f84a061dadf1c35"
+            "layout": "IPY_MODEL_c23742b6f64a4896a929a663df319a07"
           }
         },
-        "53ec6e9b981644afaf59bd79ff9b3139": {
+        "f70900ce8da44d7b98ad436057e61a14": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_a9586d3901384ce1a6bc1ca8b80dca02",
+            "style": "IPY_MODEL_366d05764cdf4615840ca2a4882c714b",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 1.88k/? [00:00&lt;00:00, 3.79kB/s]",
+            "value": " 1.88k/? [00:00&lt;00:00, 15.1kB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_ae64b57ede024289874a482c1f189134"
+            "layout": "IPY_MODEL_d80a43cd09e74f6488953d0375f16630"
           }
         },
-        "202f50faeb03486cb69ed79764051928": {
+        "7adefdefdb0d4e3c89dea3f94355a22a": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -389,7 +389,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "d2f27559128a43529f84a061dadf1c35": {
+        "c23742b6f64a4896a929a663df319a07": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -440,7 +440,7 @@
             "left": null
           }
         },
-        "a9586d3901384ce1a6bc1ca8b80dca02": {
+        "366d05764cdf4615840ca2a4882c714b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -454,7 +454,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "ae64b57ede024289874a482c1f189134": {
+        "d80a43cd09e74f6488953d0375f16630": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -505,7 +505,7 @@
             "left": null
           }
         },
-        "64ae0f4ffde9471f8444d3e648264b49": {
+        "278d86f375a2411c95ffa67ab3ead553": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -517,15 +517,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_d15caa39122f4e8cae9801870cec3126",
+            "layout": "IPY_MODEL_17c5f9d76aa143dd97b28bd022b65928",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_8cb89206491a4c44835798ae0eb0ec55",
-              "IPY_MODEL_4cbe8a8c5b9f405085e851e7b06e08fb"
+              "IPY_MODEL_3a23fd2815db4a9e932d4b24730544cf",
+              "IPY_MODEL_d1fcae5dc5ae4c4ba3a88acfc2ab5c6b"
             ]
           }
         },
-        "d15caa39122f4e8cae9801870cec3126": {
+        "17c5f9d76aa143dd97b28bd022b65928": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -576,12 +576,12 @@
             "left": null
           }
         },
-        "8cb89206491a4c44835798ae0eb0ec55": {
+        "3a23fd2815db4a9e932d4b24730544cf": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_ec34d33658aa4d4d8caf4fb59b2fb894",
+            "style": "IPY_MODEL_a9e1826f0d3b4097b55d94f6059b9c19",
             "_dom_classes": [],
             "description": "Downloading: 100%",
             "_model_name": "FloatProgressModel",
@@ -596,30 +596,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_0766de0662b144198a223a391ba0ff52"
+            "layout": "IPY_MODEL_3f1434df2ae44c6a813fdbcd536ceba1"
           }
         },
-        "4cbe8a8c5b9f405085e851e7b06e08fb": {
+        "d1fcae5dc5ae4c4ba3a88acfc2ab5c6b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_fcfde3f8021e4f22a29a6d90b560fb5c",
+            "style": "IPY_MODEL_7c83f0a51d62405998a1daf840cf8fbc",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 488k/488k [00:00&lt;00:00, 4.05MB/s]",
+            "value": " 488k/488k [00:00&lt;00:00, 3.82MB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_ac33c4ea8d584e08b73a824141c642a5"
+            "layout": "IPY_MODEL_3c5482f9f86945b6a1ca565b996e6afe"
           }
         },
-        "ec34d33658aa4d4d8caf4fb59b2fb894": {
+        "a9e1826f0d3b4097b55d94f6059b9c19": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -634,7 +634,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "0766de0662b144198a223a391ba0ff52": {
+        "3f1434df2ae44c6a813fdbcd536ceba1": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -685,7 +685,7 @@
             "left": null
           }
         },
-        "fcfde3f8021e4f22a29a6d90b560fb5c": {
+        "7c83f0a51d62405998a1daf840cf8fbc": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -699,7 +699,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "ac33c4ea8d584e08b73a824141c642a5": {
+        "3c5482f9f86945b6a1ca565b996e6afe": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -750,7 +750,7 @@
             "left": null
           }
         },
-        "1ba1ec2da5804fc892c0aa0af0f423e5": {
+        "a1c534924ac14e94b86c0896ef011bda": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -762,15 +762,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_fe423fd31e07484189cc22bd568c6f36",
+            "layout": "IPY_MODEL_99bc3614faf543c99c77981c5a244e87",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_86deb87a182945fe9940e3b495c85e1f",
-              "IPY_MODEL_fc3d1473c81a4d44961c8a8d20cfdae7"
+              "IPY_MODEL_1b99a4ada8ec41bbab8bf652ef90f199",
+              "IPY_MODEL_5b623b4e7c7d44098d0e731a1f1a650f"
             ]
           }
         },
-        "fe423fd31e07484189cc22bd568c6f36": {
+        "99bc3614faf543c99c77981c5a244e87": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -821,12 +821,12 @@
             "left": null
           }
         },
-        "86deb87a182945fe9940e3b495c85e1f": {
+        "1b99a4ada8ec41bbab8bf652ef90f199": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_ed029b0bee5645549ff15f81d169e2ca",
+            "style": "IPY_MODEL_16c50d9feaa44f8b8c8b05aff6f8d773",
             "_dom_classes": [],
             "description": "",
             "_model_name": "FloatProgressModel",
@@ -841,30 +841,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_790899725f9c43ff87f7e561709391ab"
+            "layout": "IPY_MODEL_295c22961e5846f3a674c306ccf77919"
           }
         },
-        "fc3d1473c81a4d44961c8a8d20cfdae7": {
+        "5b623b4e7c7d44098d0e731a1f1a650f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_d072f786e35f470595046ae5f934ce4a",
+            "style": "IPY_MODEL_a2d8e18039a142e98ec0192bb419b311",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 8530/0 [00:00&lt;00:00, 29282.42 examples/s]",
+            "value": " 8530/0 [00:00&lt;00:00, 30847.46 examples/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_1408c37a5d8f43f59793fc258989401d"
+            "layout": "IPY_MODEL_3ae163fe2441420cadda46c45c8b0788"
           }
         },
-        "ed029b0bee5645549ff15f81d169e2ca": {
+        "16c50d9feaa44f8b8c8b05aff6f8d773": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -879,7 +879,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "790899725f9c43ff87f7e561709391ab": {
+        "295c22961e5846f3a674c306ccf77919": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -930,7 +930,7 @@
             "left": null
           }
         },
-        "d072f786e35f470595046ae5f934ce4a": {
+        "a2d8e18039a142e98ec0192bb419b311": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -944,7 +944,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "1408c37a5d8f43f59793fc258989401d": {
+        "3ae163fe2441420cadda46c45c8b0788": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -995,7 +995,7 @@
             "left": null
           }
         },
-        "2c003880a36c497696f671a51aaff0fc": {
+        "abf1d33e12ab44a183abdfc920377d1f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -1007,15 +1007,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_39a44e93580044e186b80481c3bc5cdd",
+            "layout": "IPY_MODEL_65831e7d830a4aa6959343b3203646b9",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_9d03f521a3984f54b7268eeb4681590e",
-              "IPY_MODEL_b09116900e6548c38ef38bb7327ab10b"
+              "IPY_MODEL_71f96c798571403f8d24def284d976dd",
+              "IPY_MODEL_52ccd2b56733499ab1704b3086ebf5f3"
             ]
           }
         },
-        "39a44e93580044e186b80481c3bc5cdd": {
+        "65831e7d830a4aa6959343b3203646b9": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1066,12 +1066,12 @@
             "left": null
           }
         },
-        "9d03f521a3984f54b7268eeb4681590e": {
+        "71f96c798571403f8d24def284d976dd": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_e01c5843bda8438c95132ba621309c10",
+            "style": "IPY_MODEL_64fd5c025a0a493abe4d0e020fe7777b",
             "_dom_classes": [],
             "description": "",
             "_model_name": "FloatProgressModel",
@@ -1086,30 +1086,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_68ec33c785834b419701aa643b248e88"
+            "layout": "IPY_MODEL_ba0d9249f4c249dfb18f5a6b45b50b6a"
           }
         },
-        "b09116900e6548c38ef38bb7327ab10b": {
+        "52ccd2b56733499ab1704b3086ebf5f3": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_c52dec50b84d467b89f8b0e4690c8656",
+            "style": "IPY_MODEL_719018907f3944cab4a3678c10e6a317",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 1066/0 [00:00&lt;00:00, 16460.48 examples/s]",
+            "value": " 1066/0 [00:00&lt;00:00, 16841.68 examples/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_b5dfcb12ebe74829bd950b813242ccdd"
+            "layout": "IPY_MODEL_b3c4f8134a364dd6bd37d41943b8496f"
           }
         },
-        "e01c5843bda8438c95132ba621309c10": {
+        "64fd5c025a0a493abe4d0e020fe7777b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -1124,7 +1124,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "68ec33c785834b419701aa643b248e88": {
+        "ba0d9249f4c249dfb18f5a6b45b50b6a": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1175,7 +1175,7 @@
             "left": null
           }
         },
-        "c52dec50b84d467b89f8b0e4690c8656": {
+        "719018907f3944cab4a3678c10e6a317": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -1189,7 +1189,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "b5dfcb12ebe74829bd950b813242ccdd": {
+        "b3c4f8134a364dd6bd37d41943b8496f": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1240,7 +1240,7 @@
             "left": null
           }
         },
-        "622ea4fedef64cc7b52ffc8b5ceb9d6d": {
+        "0ad0872dac514827b2cf26bec2338efb": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -1252,15 +1252,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_397d3daec74943098408c35030af80a7",
+            "layout": "IPY_MODEL_cba481c9f6b2416da3424f347c72cdc6",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_db298eeaccd54be0ad2d3827acaa4689",
-              "IPY_MODEL_4e7bfc059a2a4b658548ab2c34bf96f2"
+              "IPY_MODEL_0b92b5b3b0384913a6aa3cd592a0bc54",
+              "IPY_MODEL_5bd85517e14a4df0bc7051479e6de15c"
             ]
           }
         },
-        "397d3daec74943098408c35030af80a7": {
+        "cba481c9f6b2416da3424f347c72cdc6": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1311,12 +1311,12 @@
             "left": null
           }
         },
-        "db298eeaccd54be0ad2d3827acaa4689": {
+        "0b92b5b3b0384913a6aa3cd592a0bc54": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_8ef4c6ec4fe64ec8970ec3837299a8b6",
+            "style": "IPY_MODEL_3abd3365cd104e419626427b5de97278",
             "_dom_classes": [],
             "description": "",
             "_model_name": "FloatProgressModel",
@@ -1331,30 +1331,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_6428ed9d905848449de3cc5040bdec94"
+            "layout": "IPY_MODEL_87969f6fc6ee41208e8cecf1ff646b67"
           }
         },
-        "4e7bfc059a2a4b658548ab2c34bf96f2": {
+        "5bd85517e14a4df0bc7051479e6de15c": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_9ea6bbf614e24828bff8910b5bc4a4aa",
+            "style": "IPY_MODEL_0f96976f61bf4ff29edac10115d1eedd",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 1066/0 [00:00&lt;00:00, 15218.94 examples/s]",
+            "value": " 1066/0 [00:00&lt;00:00, 12622.25 examples/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_cc84bd7b11694a8fa32147a577cd54d4"
+            "layout": "IPY_MODEL_de5793113feb44e2996edf83325dbe6a"
           }
         },
-        "8ef4c6ec4fe64ec8970ec3837299a8b6": {
+        "3abd3365cd104e419626427b5de97278": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -1369,7 +1369,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "6428ed9d905848449de3cc5040bdec94": {
+        "87969f6fc6ee41208e8cecf1ff646b67": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1420,7 +1420,7 @@
             "left": null
           }
         },
-        "9ea6bbf614e24828bff8910b5bc4a4aa": {
+        "0f96976f61bf4ff29edac10115d1eedd": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -1434,7 +1434,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "cc84bd7b11694a8fa32147a577cd54d4": {
+        "de5793113feb44e2996edf83325dbe6a": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1485,7 +1485,7 @@
             "left": null
           }
         },
-        "009d19f5f15c4bda9cdd53836c82862a": {
+        "4a8329b6f8ff4802bd9d6c437b84e329": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -1497,15 +1497,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_f22591f217ff4031a679408ddcb46fe1",
+            "layout": "IPY_MODEL_770c47502de04f059dc53b1cca002c9b",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_5869a3def38a4151bbc773a54d4db7b7",
-              "IPY_MODEL_2c1f43e42c61427db36ec54356995056"
+              "IPY_MODEL_9f8d42ec09d84646a786a2547906846f",
+              "IPY_MODEL_e33c206636b34e859d3c0681e3e0c558"
             ]
           }
         },
-        "f22591f217ff4031a679408ddcb46fe1": {
+        "770c47502de04f059dc53b1cca002c9b": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1556,12 +1556,12 @@
             "left": null
           }
         },
-        "5869a3def38a4151bbc773a54d4db7b7": {
+        "9f8d42ec09d84646a786a2547906846f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_f6ec6b0c18674e07bb8d87e2501c3271",
+            "style": "IPY_MODEL_d8fb334f7a2144ccbd5ab04efd441e41",
             "_dom_classes": [],
             "description": "Downloading: 100%",
             "_model_name": "FloatProgressModel",
@@ -1576,30 +1576,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_85f9fd7665994b5da7662c47f6ef06a1"
+            "layout": "IPY_MODEL_51ac628f4f544c5dbf985accba1134e8"
           }
         },
-        "2c1f43e42c61427db36ec54356995056": {
+        "e33c206636b34e859d3c0681e3e0c558": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_636c0fd99cc446c59826cced2af43226",
+            "style": "IPY_MODEL_f49b9dfff9e34b71b081fd5f17954f5d",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 899k/899k [00:01&lt;00:00, 884kB/s]",
+            "value": " 899k/899k [00:00&lt;00:00, 7.50MB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_1ed334588d51498baa513830262550a9"
+            "layout": "IPY_MODEL_2706662c519949119140b11124f14ebb"
           }
         },
-        "f6ec6b0c18674e07bb8d87e2501c3271": {
+        "d8fb334f7a2144ccbd5ab04efd441e41": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -1614,7 +1614,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "85f9fd7665994b5da7662c47f6ef06a1": {
+        "51ac628f4f544c5dbf985accba1134e8": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1665,7 +1665,7 @@
             "left": null
           }
         },
-        "636c0fd99cc446c59826cced2af43226": {
+        "f49b9dfff9e34b71b081fd5f17954f5d": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -1679,7 +1679,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "1ed334588d51498baa513830262550a9": {
+        "2706662c519949119140b11124f14ebb": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1730,7 +1730,7 @@
             "left": null
           }
         },
-        "afc06ccf7f354d269442f1b29f6e2110": {
+        "641e2f656b0849628c0511b8d0e00236": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -1742,15 +1742,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_570a871cd31d401f8f082bd824557624",
+            "layout": "IPY_MODEL_ad68cbc068e54ac4a3db94ef4ffacaf9",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_54e9d5617f724e1eb72b42782ad5f25c",
-              "IPY_MODEL_f902898ae06346d095a422e2c520fce4"
+              "IPY_MODEL_c1317b7e87344bf28299497a4f616b4d",
+              "IPY_MODEL_328d5387c5024554a9e0e3c3e3c00a64"
             ]
           }
         },
-        "570a871cd31d401f8f082bd824557624": {
+        "ad68cbc068e54ac4a3db94ef4ffacaf9": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1801,12 +1801,12 @@
             "left": null
           }
         },
-        "54e9d5617f724e1eb72b42782ad5f25c": {
+        "c1317b7e87344bf28299497a4f616b4d": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_7615117334cc4309a52d8990b754cf23",
+            "style": "IPY_MODEL_d4d48e22fcc54caba645e9bb6204d102",
             "_dom_classes": [],
             "description": "Downloading: 100%",
             "_model_name": "FloatProgressModel",
@@ -1821,30 +1821,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_d4cb0eef066e4fa2900b182dcf959a8f"
+            "layout": "IPY_MODEL_b25a3e07181149798938e93af2ac9c82"
           }
         },
-        "f902898ae06346d095a422e2c520fce4": {
+        "328d5387c5024554a9e0e3c3e3c00a64": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_3b1942afe4b744c9b66a7cfae8fd6e88",
+            "style": "IPY_MODEL_ab6436322cbf49e18d2e31b64fbee854",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 456k/456k [00:00&lt;00:00, 1.16MB/s]",
+            "value": " 456k/456k [00:00&lt;00:00, 4.38MB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_62ea91e8d13640788d6981875854c293"
+            "layout": "IPY_MODEL_9e14ab86471243cc97d19ab8c5f878eb"
           }
         },
-        "7615117334cc4309a52d8990b754cf23": {
+        "d4d48e22fcc54caba645e9bb6204d102": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -1859,7 +1859,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "d4cb0eef066e4fa2900b182dcf959a8f": {
+        "b25a3e07181149798938e93af2ac9c82": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1910,7 +1910,7 @@
             "left": null
           }
         },
-        "3b1942afe4b744c9b66a7cfae8fd6e88": {
+        "ab6436322cbf49e18d2e31b64fbee854": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -1924,7 +1924,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "62ea91e8d13640788d6981875854c293": {
+        "9e14ab86471243cc97d19ab8c5f878eb": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1975,7 +1975,7 @@
             "left": null
           }
         },
-        "9a1311fee05c4180887869f5169d65f9": {
+        "8d73e2f87c9a4f459120c52c2c13b99b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -1987,15 +1987,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_b53d1c6ec19c4cb7a94fd77727cb8b6e",
+            "layout": "IPY_MODEL_904dab0f997f4d528ec29b03cfa3f9ce",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_4bebecbd7b4940e59690bfdd106efbf8",
-              "IPY_MODEL_967ce96c8388492ca4ef18716224f9db"
+              "IPY_MODEL_7caf3511f7a8480f9231d0ebc18ad464",
+              "IPY_MODEL_ce3dc2613747408e988663b2d7c0fca7"
             ]
           }
         },
-        "b53d1c6ec19c4cb7a94fd77727cb8b6e": {
+        "904dab0f997f4d528ec29b03cfa3f9ce": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2046,12 +2046,12 @@
             "left": null
           }
         },
-        "4bebecbd7b4940e59690bfdd106efbf8": {
+        "7caf3511f7a8480f9231d0ebc18ad464": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_970f50c3644c47fb9ecff569b11cf21a",
+            "style": "IPY_MODEL_818ac8c0164c44dcb75367ba66c403eb",
             "_dom_classes": [],
             "description": "100%",
             "_model_name": "FloatProgressModel",
@@ -2066,30 +2066,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_dd3108dd9e6141368700ab6f457e101b"
+            "layout": "IPY_MODEL_d744cb6c14e74631a9b682663c3c48eb"
           }
         },
-        "967ce96c8388492ca4ef18716224f9db": {
+        "ce3dc2613747408e988663b2d7c0fca7": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_869afef38f534b4d967fb82f668a0de2",
+            "style": "IPY_MODEL_c668e22e3fa44822b2348c66125e52eb",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 9/9 [00:02&lt;00:00,  3.21ba/s]",
+            "value": " 9/9 [00:02&lt;00:00,  3.37ba/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_065feaaac34c45698d07a6440ba855ec"
+            "layout": "IPY_MODEL_5a58d2e05ab547178bde46f38b3f2508"
           }
         },
-        "970f50c3644c47fb9ecff569b11cf21a": {
+        "818ac8c0164c44dcb75367ba66c403eb": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -2104,7 +2104,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "dd3108dd9e6141368700ab6f457e101b": {
+        "d744cb6c14e74631a9b682663c3c48eb": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2155,7 +2155,7 @@
             "left": null
           }
         },
-        "869afef38f534b4d967fb82f668a0de2": {
+        "c668e22e3fa44822b2348c66125e52eb": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -2169,7 +2169,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "065feaaac34c45698d07a6440ba855ec": {
+        "5a58d2e05ab547178bde46f38b3f2508": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2220,7 +2220,7 @@
             "left": null
           }
         },
-        "2d2c2526d5884c5b95b144ed77e233b4": {
+        "a37a7a7a2f8d4d1da71fa62a09cba0f8": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -2232,15 +2232,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_0505ed1ff29b4ea188cadfbbb57b58f3",
+            "layout": "IPY_MODEL_2a64f468682649338d5c5e39797d4619",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_b34fc80d92ea406ca0c9fd07f073fef9",
-              "IPY_MODEL_1b065a0884544683b6cf6a247a626de2"
+              "IPY_MODEL_f1d344a1829d48c0b869c928874017be",
+              "IPY_MODEL_8d239eb5fdeb4c37ad7f8b904eda66d7"
             ]
           }
         },
-        "0505ed1ff29b4ea188cadfbbb57b58f3": {
+        "2a64f468682649338d5c5e39797d4619": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2291,12 +2291,12 @@
             "left": null
           }
         },
-        "b34fc80d92ea406ca0c9fd07f073fef9": {
+        "f1d344a1829d48c0b869c928874017be": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_cb020c297ccd4e179fa1f43ca0c2da64",
+            "style": "IPY_MODEL_fbead18c6de84e6c999c57570edb4660",
             "_dom_classes": [],
             "description": "100%",
             "_model_name": "FloatProgressModel",
@@ -2311,30 +2311,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_9d213c524a0d4c608cf2a6d0c2aa21d4"
+            "layout": "IPY_MODEL_30a0b7c3b3a54806ba701d660b0a1e8c"
           }
         },
-        "1b065a0884544683b6cf6a247a626de2": {
+        "8d239eb5fdeb4c37ad7f8b904eda66d7": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_6d8d4798ffdd40558ff722af0fea0a66",
+            "style": "IPY_MODEL_796e808439a8450299b51d524f9316f8",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 2/2 [00:00&lt;00:00,  5.97ba/s]",
+            "value": " 2/2 [00:00&lt;00:00,  6.32ba/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_9b17e5e89e034fb5a721bd7efc74d426"
+            "layout": "IPY_MODEL_1a20bf61207d45ddb325719d4b7c9148"
           }
         },
-        "cb020c297ccd4e179fa1f43ca0c2da64": {
+        "fbead18c6de84e6c999c57570edb4660": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -2349,7 +2349,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "9d213c524a0d4c608cf2a6d0c2aa21d4": {
+        "30a0b7c3b3a54806ba701d660b0a1e8c": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2400,7 +2400,7 @@
             "left": null
           }
         },
-        "6d8d4798ffdd40558ff722af0fea0a66": {
+        "796e808439a8450299b51d524f9316f8": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -2414,7 +2414,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "9b17e5e89e034fb5a721bd7efc74d426": {
+        "1a20bf61207d45ddb325719d4b7c9148": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2465,7 +2465,7 @@
             "left": null
           }
         },
-        "3528a71234c6481aa69ba04072d939ee": {
+        "d7259df55724410398d772e596492785": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -2477,15 +2477,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_eddce3a8e86c42b9b6a03181f4bf89e4",
+            "layout": "IPY_MODEL_102db28574914068945ac5a21a881272",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_a5927dbeb9c74ed7a14d5920959dfd2b",
-              "IPY_MODEL_763977423f4d438aa831814cac9d87d3"
+              "IPY_MODEL_3012236fd9a645dc83acc79fc18740a6",
+              "IPY_MODEL_990fdec67b3e476bb857b3a29ee40a18"
             ]
           }
         },
-        "eddce3a8e86c42b9b6a03181f4bf89e4": {
+        "102db28574914068945ac5a21a881272": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2536,12 +2536,12 @@
             "left": null
           }
         },
-        "a5927dbeb9c74ed7a14d5920959dfd2b": {
+        "3012236fd9a645dc83acc79fc18740a6": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_de87322ae9b54083820c4f53944de951",
+            "style": "IPY_MODEL_c2380b3d6ef649b4a746fd7d2987a53f",
             "_dom_classes": [],
             "description": "100%",
             "_model_name": "FloatProgressModel",
@@ -2556,30 +2556,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_e6ac685876da40e9bc0765fd0d3ecc20"
+            "layout": "IPY_MODEL_74dc804ece004364b02afaa0f2e445e6"
           }
         },
-        "763977423f4d438aa831814cac9d87d3": {
+        "990fdec67b3e476bb857b3a29ee40a18": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_91b13af76e314caca68161e94bb7a4fe",
+            "style": "IPY_MODEL_662f444e5b5d406ba6977c3ca2ac3140",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 2/2 [00:00&lt;00:00,  5.96ba/s]",
+            "value": " 2/2 [00:00&lt;00:00,  6.33ba/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_2b7b5e6d11ef4702aee411d9c04c16e8"
+            "layout": "IPY_MODEL_5fa022229fc3451e8f4ca55d99f5f399"
           }
         },
-        "de87322ae9b54083820c4f53944de951": {
+        "c2380b3d6ef649b4a746fd7d2987a53f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -2594,7 +2594,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "e6ac685876da40e9bc0765fd0d3ecc20": {
+        "74dc804ece004364b02afaa0f2e445e6": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2645,7 +2645,7 @@
             "left": null
           }
         },
-        "91b13af76e314caca68161e94bb7a4fe": {
+        "662f444e5b5d406ba6977c3ca2ac3140": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -2659,7 +2659,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "2b7b5e6d11ef4702aee411d9c04c16e8": {
+        "5fa022229fc3451e8f4ca55d99f5f399": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2710,7 +2710,7 @@
             "left": null
           }
         },
-        "29dc93819e9740988234a18653b0eab0": {
+        "9da723c91128430aaf0de657b5d78614": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -2722,15 +2722,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_531905d0c4ba41c88d859a8dc7a6633b",
+            "layout": "IPY_MODEL_fcaa1a0b279f44a383b890e21e7fab98",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_51a65ebcf55e445695b82a78cf10915c",
-              "IPY_MODEL_353816c214cb473392ae4b297834da25"
+              "IPY_MODEL_c6f0b71cd4044a5eb4a3807b1aabb2a3",
+              "IPY_MODEL_5c77f543bafe4e40a0ef7fdcc46ca840"
             ]
           }
         },
-        "531905d0c4ba41c88d859a8dc7a6633b": {
+        "fcaa1a0b279f44a383b890e21e7fab98": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2781,12 +2781,12 @@
             "left": null
           }
         },
-        "51a65ebcf55e445695b82a78cf10915c": {
+        "c6f0b71cd4044a5eb4a3807b1aabb2a3": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_1116f49f50984fa58ce0094061f1b1d4",
+            "style": "IPY_MODEL_5294399a5b17497685ce84d755786427",
             "_dom_classes": [],
             "description": "Downloading: 100%",
             "_model_name": "FloatProgressModel",
@@ -2801,30 +2801,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_0151f5a2fd434c7f85b6566eec890d3e"
+            "layout": "IPY_MODEL_42ae0acfec4644bfb39110c2d220da35"
           }
         },
-        "353816c214cb473392ae4b297834da25": {
+        "5c77f543bafe4e40a0ef7fdcc46ca840": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_0de7cb0f177e4c3e90056e86154a72af",
+            "style": "IPY_MODEL_377bfbd756034a638a79f962e3002b55",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 481/481 [00:00&lt;00:00, 3.09kB/s]",
+            "value": " 481/481 [00:00&lt;00:00, 2.43kB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_5763556e884b4501bfc2a74f8ba63250"
+            "layout": "IPY_MODEL_4207ecdfbb8d4be7ab8a37f7025e8ed0"
           }
         },
-        "1116f49f50984fa58ce0094061f1b1d4": {
+        "5294399a5b17497685ce84d755786427": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -2839,7 +2839,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "0151f5a2fd434c7f85b6566eec890d3e": {
+        "42ae0acfec4644bfb39110c2d220da35": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2890,7 +2890,7 @@
             "left": null
           }
         },
-        "0de7cb0f177e4c3e90056e86154a72af": {
+        "377bfbd756034a638a79f962e3002b55": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -2904,7 +2904,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "5763556e884b4501bfc2a74f8ba63250": {
+        "4207ecdfbb8d4be7ab8a37f7025e8ed0": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2955,7 +2955,7 @@
             "left": null
           }
         },
-        "43218c9674f041428625ea02f3ca0de6": {
+        "64f27e101aeb4b66aae1f280401adcc8": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -2967,15 +2967,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_4cba233614e14c45aed4eb1faa9283fa",
+            "layout": "IPY_MODEL_243fc2fe7d9d492cb95e7e84da403a27",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_5b3324b8f8c041e0b358c7b8077a134e",
-              "IPY_MODEL_4e3bafc786f6417caaa8c788c07c27a2"
+              "IPY_MODEL_14e8e514752c43c5be0613a90342ec28",
+              "IPY_MODEL_b60924467c084300bc84b3e2454a92e4"
             ]
           }
         },
-        "4cba233614e14c45aed4eb1faa9283fa": {
+        "243fc2fe7d9d492cb95e7e84da403a27": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -3026,12 +3026,12 @@
             "left": null
           }
         },
-        "5b3324b8f8c041e0b358c7b8077a134e": {
+        "14e8e514752c43c5be0613a90342ec28": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_669ee06c6687491eb2e9d331129406f8",
+            "style": "IPY_MODEL_2963c36cb8d747a2890dc5d1b287d345",
             "_dom_classes": [],
             "description": "Downloading: 100%",
             "_model_name": "FloatProgressModel",
@@ -3046,30 +3046,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_357ec0469865467498ea6145441d71ce"
+            "layout": "IPY_MODEL_bf307055977f473e99b94a90c95f8269"
           }
         },
-        "4e3bafc786f6417caaa8c788c07c27a2": {
+        "b60924467c084300bc84b3e2454a92e4": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_26640724c26340e3a49b983a7385d569",
+            "style": "IPY_MODEL_41a7a6711efb495fbdca9b40ec2d0a59",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 501M/501M [00:11&lt;00:00, 42.2MB/s]",
+            "value": " 501M/501M [00:26&lt;00:00, 19.1MB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_697b9074a0a44e66850be5b9da708d03"
+            "layout": "IPY_MODEL_29819fe095904d3e8d15522c7a9ef416"
           }
         },
-        "669ee06c6687491eb2e9d331129406f8": {
+        "2963c36cb8d747a2890dc5d1b287d345": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -3084,7 +3084,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "357ec0469865467498ea6145441d71ce": {
+        "bf307055977f473e99b94a90c95f8269": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -3135,7 +3135,7 @@
             "left": null
           }
         },
-        "26640724c26340e3a49b983a7385d569": {
+        "41a7a6711efb495fbdca9b40ec2d0a59": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -3149,1967 +3149,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "697b9074a0a44e66850be5b9da708d03": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "4918bcb45e494ec0a16fa4cd68072888": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_d998e81fb7324ec5aec0afc6ccea6fc3",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_61da2ccc4b2d4a568ddde68877e3ffc5",
-              "IPY_MODEL_c99c80753ebf47fab7eed74f4be56972"
-            ]
-          }
-        },
-        "d998e81fb7324ec5aec0afc6ccea6fc3": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "61da2ccc4b2d4a568ddde68877e3ffc5": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_2338b529b7f843a7a5687fa36f128a3f",
-            "_dom_classes": [],
-            "description": "Epoch: 100%",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 6,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 6,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_706d9a3c75d64238a3ffa7241f8f1f64"
-          }
-        },
-        "c99c80753ebf47fab7eed74f4be56972": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_c299444f0aac432297d5131daa85ea53",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 6/6 [09:39&lt;00:00, 96.57s/it]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_d9045f5f8f24420f99c65efde4db7864"
-          }
-        },
-        "2338b529b7f843a7a5687fa36f128a3f": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "initial",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "706d9a3c75d64238a3ffa7241f8f1f64": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "c299444f0aac432297d5131daa85ea53": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "d9045f5f8f24420f99c65efde4db7864": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "8d188fe6e5474e11a810d6827c8796c8": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_f73c9f049b124e5d96aa9c80f9be1006",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_2d16e52ba07a496096abee747df710f7",
-              "IPY_MODEL_720faf02b77a4ecd97fbb9de08257157"
-            ]
-          }
-        },
-        "f73c9f049b124e5d96aa9c80f9be1006": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "2d16e52ba07a496096abee747df710f7": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_18fc828f494d46cfad6a1bcf35416d96",
-            "_dom_classes": [],
-            "description": "Iteration: 100%",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 267,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 267,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_9dfa41512b8b43fba84c82aceab82137"
-          }
-        },
-        "720faf02b77a4ecd97fbb9de08257157": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_340da1da961f4b0c835bd531bba517ae",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 267/267 [01:34&lt;00:00,  2.84it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_11389bbfd8df401bad4fdedd675d27da"
-          }
-        },
-        "18fc828f494d46cfad6a1bcf35416d96": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "initial",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "9dfa41512b8b43fba84c82aceab82137": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "340da1da961f4b0c835bd531bba517ae": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "11389bbfd8df401bad4fdedd675d27da": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "3bed0b6219b248bd9ea6e4d3c9728fa9": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_1ca3f4c282394e23aefeb02c13e571cc",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_442b1806d8f542bc9d4afda8b794e724",
-              "IPY_MODEL_a1a9a37cd2514188b347cc40039ae9ce"
-            ]
-          }
-        },
-        "1ca3f4c282394e23aefeb02c13e571cc": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "442b1806d8f542bc9d4afda8b794e724": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_0ced897cef3b4344a993b004c6138a19",
-            "_dom_classes": [],
-            "description": "Iteration: 100%",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 267,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 267,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_c6680b04efd3469ab12e17cfe1b1dfc2"
-          }
-        },
-        "a1a9a37cd2514188b347cc40039ae9ce": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_d4e9584a099341fc8df5626fc9432597",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 267/267 [01:37&lt;00:00,  2.74it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_15fc7c1e00ec4eb9a8c4ce1ec835aeb2"
-          }
-        },
-        "0ced897cef3b4344a993b004c6138a19": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "initial",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "c6680b04efd3469ab12e17cfe1b1dfc2": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "d4e9584a099341fc8df5626fc9432597": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "15fc7c1e00ec4eb9a8c4ce1ec835aeb2": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "66e3df94b86a4513a420e9b537686255": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_ccc4a24f08ef40668411940cdc3b4cf6",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_43b0da110e454c23919ff012cc0b93df",
-              "IPY_MODEL_9c74a88e05c64441846205ec2519fb4a"
-            ]
-          }
-        },
-        "ccc4a24f08ef40668411940cdc3b4cf6": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "43b0da110e454c23919ff012cc0b93df": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_eebcc6a327fb496a8917e49fee8e8122",
-            "_dom_classes": [],
-            "description": "Iteration: 100%",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 267,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 267,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_0ad8ed8b44eb4870821f29ab498de5d2"
-          }
-        },
-        "9c74a88e05c64441846205ec2519fb4a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_05f3a5caef254f238f5ada346946836f",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 267/267 [01:36&lt;00:00,  2.78it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_4464a13d4e714633af2e5f6b208f4380"
-          }
-        },
-        "eebcc6a327fb496a8917e49fee8e8122": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "initial",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "0ad8ed8b44eb4870821f29ab498de5d2": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "05f3a5caef254f238f5ada346946836f": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "4464a13d4e714633af2e5f6b208f4380": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "dd0f4e1230cb4421a3209c0e095669ee": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_491fb058b02b4d67b771b4b86c5a679d",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_7319072116914089988acf05a220e3e8",
-              "IPY_MODEL_63ed9256615d4229975dbdf7a168da3b"
-            ]
-          }
-        },
-        "491fb058b02b4d67b771b4b86c5a679d": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "7319072116914089988acf05a220e3e8": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_250f16d7d77f464db0bb524c9ec9ab20",
-            "_dom_classes": [],
-            "description": "Iteration: 100%",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 267,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 267,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_68bbd81e25904c05aab55e0ced718fb0"
-          }
-        },
-        "63ed9256615d4229975dbdf7a168da3b": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_be8260cab646476e871487abb32622bb",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 267/267 [01:37&lt;00:00,  2.74it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_d1b6a0dd295c453b8a1b24e3d73d6a0f"
-          }
-        },
-        "250f16d7d77f464db0bb524c9ec9ab20": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "initial",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "68bbd81e25904c05aab55e0ced718fb0": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "be8260cab646476e871487abb32622bb": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "d1b6a0dd295c453b8a1b24e3d73d6a0f": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "eff9695c671349e8a9ad424702663361": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_5b004f46dc554672b85ceebc427c0504",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_118fd7c5ec8c4737b42146f592bb0932",
-              "IPY_MODEL_93b9a59513594577a90f4478c3da5bf2"
-            ]
-          }
-        },
-        "5b004f46dc554672b85ceebc427c0504": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "118fd7c5ec8c4737b42146f592bb0932": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_51cda8efc56c49de91adb8343c402e86",
-            "_dom_classes": [],
-            "description": "Iteration: 100%",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 267,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 267,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_47336d84a1394a218b9120e765e52a16"
-          }
-        },
-        "93b9a59513594577a90f4478c3da5bf2": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_2ad5090f718f43f6a8504bc43630fdcc",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 267/267 [01:36&lt;00:00,  2.78it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_2a16cd20241e442fbc13b7b375a99b86"
-          }
-        },
-        "51cda8efc56c49de91adb8343c402e86": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "initial",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "47336d84a1394a218b9120e765e52a16": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "2ad5090f718f43f6a8504bc43630fdcc": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "2a16cd20241e442fbc13b7b375a99b86": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "3095d71f26594d70aea89227e45aefce": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_a68de4ce160148458ea595c24fea7643",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_719659e3d8fd48b1b038620daf7760e6",
-              "IPY_MODEL_c862f3e51bb6490f8237655378d00dd6"
-            ]
-          }
-        },
-        "a68de4ce160148458ea595c24fea7643": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "719659e3d8fd48b1b038620daf7760e6": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_9e18cf85ee0f41b3ab3e45e91fb69417",
-            "_dom_classes": [],
-            "description": "Iteration: 100%",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 267,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 267,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_1065aff8cdb2406ab60ae8e65065472b"
-          }
-        },
-        "c862f3e51bb6490f8237655378d00dd6": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_2a5c907e1ca544f3b041be19615fb66d",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 267/267 [01:38&lt;00:00,  2.72it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_401557a225ab43f4b16fa00c50b4d717"
-          }
-        },
-        "9e18cf85ee0f41b3ab3e45e91fb69417": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "initial",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "1065aff8cdb2406ab60ae8e65065472b": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "2a5c907e1ca544f3b041be19615fb66d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "401557a225ab43f4b16fa00c50b4d717": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "15f9d1b026b24e119b1428d4e9eb3651": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_b97b91efee334b9380886ed3366f2ec1",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_06b961c8e115456490a5e6a430effc71",
-              "IPY_MODEL_6c37ed5907a74be1a59a518136ff11ac"
-            ]
-          }
-        },
-        "b97b91efee334b9380886ed3366f2ec1": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "06b961c8e115456490a5e6a430effc71": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_dbdc0506e5e741c5a77b5eaddca7ebe6",
-            "_dom_classes": [],
-            "description": "Evaluation: 100%",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 34,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 34,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_50191dee959e4fec89b1011506b3e39c"
-          }
-        },
-        "6c37ed5907a74be1a59a518136ff11ac": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_d68c11a186fd491fa35f214592da7a3b",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 34/34 [00:06&lt;00:00,  5.20it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_a82c817d8ca54fb4ba711fae4da2d3f5"
-          }
-        },
-        "dbdc0506e5e741c5a77b5eaddca7ebe6": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "initial",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "50191dee959e4fec89b1011506b3e39c": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "d68c11a186fd491fa35f214592da7a3b": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "a82c817d8ca54fb4ba711fae4da2d3f5": {
+        "29819fe095904d3e8d15522c7a9ef416": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -5195,14 +3235,71 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "ju-alwbHmKYA"
+        "id": "ju-alwbHmKYA",
+        "outputId": "36e747e5-7c9a-456f-cb80-234e75dd75ec",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
-        "!pip install git+https://github.com/Adapter-Hub/adapter-transformers.git\n",
+        "!pip install adapter-transformers\n",
         "!pip install datasets"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Collecting adapter-transformers\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/9d/44/1370c187aba1349d56d6813ec4de54644d15e154983050f4923ce5455069/adapter_transformers-1.1.0-py3-none-any.whl (1.3MB)\n",
+            "\r\u001b[K     |▎                               | 10kB 21.1MB/s eta 0:00:01\r\u001b[K     |▌                               | 20kB 25.3MB/s eta 0:00:01\r\u001b[K     |▊                               | 30kB 19.1MB/s eta 0:00:01\r\u001b[K     |█                               | 40kB 17.3MB/s eta 0:00:01\r\u001b[K     |█▎                              | 51kB 13.5MB/s eta 0:00:01\r\u001b[K     |█▌                              | 61kB 13.5MB/s eta 0:00:01\r\u001b[K     |█▊                              | 71kB 13.1MB/s eta 0:00:01\r\u001b[K     |██                              | 81kB 13.5MB/s eta 0:00:01\r\u001b[K     |██▏                             | 92kB 13.6MB/s eta 0:00:01\r\u001b[K     |██▌                             | 102kB 14.7MB/s eta 0:00:01\r\u001b[K     |██▊                             | 112kB 14.7MB/s eta 0:00:01\r\u001b[K     |███                             | 122kB 14.7MB/s eta 0:00:01\r\u001b[K     |███▏                            | 133kB 14.7MB/s eta 0:00:01\r\u001b[K     |███▍                            | 143kB 14.7MB/s eta 0:00:01\r\u001b[K     |███▊                            | 153kB 14.7MB/s eta 0:00:01\r\u001b[K     |████                            | 163kB 14.7MB/s eta 0:00:01\r\u001b[K     |████▏                           | 174kB 14.7MB/s eta 0:00:01\r\u001b[K     |████▍                           | 184kB 14.7MB/s eta 0:00:01\r\u001b[K     |████▊                           | 194kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████                           | 204kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████▏                          | 215kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████▍                          | 225kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████▋                          | 235kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████                          | 245kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████▏                         | 256kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████▍                         | 266kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████▋                         | 276kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████▉                         | 286kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████▏                        | 296kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████▍                        | 307kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████▋                        | 317kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████▉                        | 327kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████▏                       | 337kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████▍                       | 348kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████▋                       | 358kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████▉                       | 368kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████                       | 378kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████▍                      | 389kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████▋                      | 399kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████▉                      | 409kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████                      | 419kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████▎                     | 430kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████▋                     | 440kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████▉                     | 450kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████                     | 460kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████▎                    | 471kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████▌                    | 481kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████▉                    | 491kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████                    | 501kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████▎                   | 512kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████▌                   | 522kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████▉                   | 532kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████                   | 542kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████▎                  | 552kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████▌                  | 563kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████▊                  | 573kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████                  | 583kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████▎                 | 593kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████▌                 | 604kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████▊                 | 614kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████                 | 624kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████▎                | 634kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████▌                | 645kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████▊                | 655kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████                | 665kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████▎               | 675kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████▌               | 686kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████▊               | 696kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████               | 706kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████▏              | 716kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████▌              | 727kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████▊              | 737kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████              | 747kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████▏             | 757kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████▍             | 768kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████▊             | 778kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████             | 788kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████▏            | 798kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████▍            | 808kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████▊            | 819kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████            | 829kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████▏           | 839kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████▍           | 849kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████▋           | 860kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████           | 870kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████▏          | 880kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████▍          | 890kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████▋          | 901kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████▉          | 911kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████▏         | 921kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████▍         | 931kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████▋         | 942kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████▉         | 952kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████         | 962kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████▍        | 972kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████▋        | 983kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████▉        | 993kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████        | 1.0MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████▍       | 1.0MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████▋       | 1.0MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████▉       | 1.0MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████       | 1.0MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▎      | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▋      | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▉      | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████      | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▎     | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▌     | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▉     | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████     | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████▎    | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████▌    | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████▉    | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████    | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▎   | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▌   | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▊   | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████   | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████▎  | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████▌  | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████▊  | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████  | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▎ | 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▌ | 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▊ | 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████ | 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████▎| 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████▌| 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████▊| 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 1.3MB 14.7MB/s \n",
+            "\u001b[?25hRequirement already satisfied: protobuf in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (3.12.4)\n",
+            "Requirement already satisfied: sentencepiece==0.1.91 in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (0.1.91)\n",
+            "Requirement already satisfied: tokenizers==0.9.3 in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (0.9.3)\n",
+            "Requirement already satisfied: sacremoses in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (0.0.43)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (2.23.0)\n",
+            "Requirement already satisfied: dataclasses; python_version < \"3.7\" in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (0.8)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (1.18.5)\n",
+            "Requirement already satisfied: regex!=2019.12.17 in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (2019.12.20)\n",
+            "Requirement already satisfied: tqdm>=4.27 in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (4.41.1)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (20.7)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (3.0.12)\n",
+            "Requirement already satisfied: six>=1.9 in /usr/local/lib/python3.6/dist-packages (from protobuf->adapter-transformers) (1.15.0)\n",
+            "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from protobuf->adapter-transformers) (50.3.2)\n",
+            "Requirement already satisfied: click in /usr/local/lib/python3.6/dist-packages (from sacremoses->adapter-transformers) (7.1.2)\n",
+            "Requirement already satisfied: joblib in /usr/local/lib/python3.6/dist-packages (from sacremoses->adapter-transformers) (0.17.0)\n",
+            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/dist-packages (from requests->adapter-transformers) (2.10)\n",
+            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.6/dist-packages (from requests->adapter-transformers) (1.24.3)\n",
+            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests->adapter-transformers) (3.0.4)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests->adapter-transformers) (2020.12.5)\n",
+            "Requirement already satisfied: pyparsing>=2.0.2 in /usr/local/lib/python3.6/dist-packages (from packaging->adapter-transformers) (2.4.7)\n",
+            "Installing collected packages: adapter-transformers\n",
+            "Successfully installed adapter-transformers-1.1.0\n",
+            "Collecting datasets\n",
+            "  Using cached https://files.pythonhosted.org/packages/1a/38/0c24dce24767386123d528d27109024220db0e7a04467b658d587695241a/datasets-1.1.3-py3-none-any.whl\n",
+            "Requirement already satisfied: numpy>=1.17 in /usr/local/lib/python3.6/dist-packages (from datasets) (1.18.5)\n",
+            "Requirement already satisfied: tqdm<4.50.0,>=4.27 in /usr/local/lib/python3.6/dist-packages (from datasets) (4.41.1)\n",
+            "Collecting pyarrow>=0.17.1\n",
+            "  Using cached https://files.pythonhosted.org/packages/d7/e1/27958a70848f8f7089bff8d6ebe42519daf01f976d28b481e1bfd52c8097/pyarrow-2.0.0-cp36-cp36m-manylinux2014_x86_64.whl\n",
+            "Requirement already satisfied: requests>=2.19.0 in /usr/local/lib/python3.6/dist-packages (from datasets) (2.23.0)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.6/dist-packages (from datasets) (1.1.5)\n",
+            "Requirement already satisfied: xxhash in /usr/local/lib/python3.6/dist-packages (from datasets) (2.0.0)\n",
+            "Requirement already satisfied: dill in /usr/local/lib/python3.6/dist-packages (from datasets) (0.3.3)\n",
+            "Requirement already satisfied: dataclasses; python_version < \"3.7\" in /usr/local/lib/python3.6/dist-packages (from datasets) (0.8)\n",
+            "Requirement already satisfied: multiprocess in /usr/local/lib/python3.6/dist-packages (from datasets) (0.70.11.1)\n",
+            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (1.24.3)\n",
+            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (2.10)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (2020.12.5)\n",
+            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (3.0.4)\n",
+            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.6/dist-packages (from pandas->datasets) (2018.9)\n",
+            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.6/dist-packages (from pandas->datasets) (2.8.1)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.6/dist-packages (from python-dateutil>=2.7.3->pandas->datasets) (1.15.0)\n",
+            "Installing collected packages: pyarrow, datasets\n",
+            "Successfully installed datasets-1.1.3 pyarrow-2.0.0\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -5223,57 +3320,57 @@
           "base_uri": "https://localhost:8080/",
           "height": 262,
           "referenced_widgets": [
-            "01d575495f3449f1bb900454d851de7c",
-            "3cbbb1f26fff4fa4960886ecd9ddf7a5",
-            "b078d98497a94753827930a620a05824",
-            "6b8b58c14c4246d4a5f062ead85b9c2f",
-            "ff436e4a2cc04b2680fc413480965595",
-            "13f6df5e854e4b9e99e727bccdeb3475",
-            "93b0ddfe6cde4d21980f00cdfb23fe18",
-            "a3ada4e3a4ff4f85b4de16e79788fa8b",
-            "cc11d16e71a44c18b6428d1a2b63a235",
-            "a4269ca6b9454424b58a8e4e7e74db0f",
-            "bd322bd508ca4df788669b8dd8fd8f0f",
-            "53ec6e9b981644afaf59bd79ff9b3139",
-            "202f50faeb03486cb69ed79764051928",
-            "d2f27559128a43529f84a061dadf1c35",
-            "a9586d3901384ce1a6bc1ca8b80dca02",
-            "ae64b57ede024289874a482c1f189134",
-            "64ae0f4ffde9471f8444d3e648264b49",
-            "d15caa39122f4e8cae9801870cec3126",
-            "8cb89206491a4c44835798ae0eb0ec55",
-            "4cbe8a8c5b9f405085e851e7b06e08fb",
-            "ec34d33658aa4d4d8caf4fb59b2fb894",
-            "0766de0662b144198a223a391ba0ff52",
-            "fcfde3f8021e4f22a29a6d90b560fb5c",
-            "ac33c4ea8d584e08b73a824141c642a5",
-            "1ba1ec2da5804fc892c0aa0af0f423e5",
-            "fe423fd31e07484189cc22bd568c6f36",
-            "86deb87a182945fe9940e3b495c85e1f",
-            "fc3d1473c81a4d44961c8a8d20cfdae7",
-            "ed029b0bee5645549ff15f81d169e2ca",
-            "790899725f9c43ff87f7e561709391ab",
-            "d072f786e35f470595046ae5f934ce4a",
-            "1408c37a5d8f43f59793fc258989401d",
-            "2c003880a36c497696f671a51aaff0fc",
-            "39a44e93580044e186b80481c3bc5cdd",
-            "9d03f521a3984f54b7268eeb4681590e",
-            "b09116900e6548c38ef38bb7327ab10b",
-            "e01c5843bda8438c95132ba621309c10",
-            "68ec33c785834b419701aa643b248e88",
-            "c52dec50b84d467b89f8b0e4690c8656",
-            "b5dfcb12ebe74829bd950b813242ccdd",
-            "622ea4fedef64cc7b52ffc8b5ceb9d6d",
-            "397d3daec74943098408c35030af80a7",
-            "db298eeaccd54be0ad2d3827acaa4689",
-            "4e7bfc059a2a4b658548ab2c34bf96f2",
-            "8ef4c6ec4fe64ec8970ec3837299a8b6",
-            "6428ed9d905848449de3cc5040bdec94",
-            "9ea6bbf614e24828bff8910b5bc4a4aa",
-            "cc84bd7b11694a8fa32147a577cd54d4"
+            "c3aa99f89b76454c96a862454a359f6b",
+            "7487c6cc822d491597a3aada5af8e454",
+            "c434f4813daf4dd699c553d2a6736e00",
+            "f9f50a85c48b4d4786ac16836ef0e083",
+            "cb1ee710a1344fe8b0c817249fb51e3d",
+            "adb199dacb9c4881be7ae6ffdd665b54",
+            "643c34677a93499fa233e5f52649b0e0",
+            "94832fd6f4f7419bac117598f804d1c6",
+            "601e07e7e60e440aab0792c52c4e59eb",
+            "c472912011a6462088eeeb2baba50bf0",
+            "075ff4547bcd44e48ec9255ade034dcf",
+            "f70900ce8da44d7b98ad436057e61a14",
+            "7adefdefdb0d4e3c89dea3f94355a22a",
+            "c23742b6f64a4896a929a663df319a07",
+            "366d05764cdf4615840ca2a4882c714b",
+            "d80a43cd09e74f6488953d0375f16630",
+            "278d86f375a2411c95ffa67ab3ead553",
+            "17c5f9d76aa143dd97b28bd022b65928",
+            "3a23fd2815db4a9e932d4b24730544cf",
+            "d1fcae5dc5ae4c4ba3a88acfc2ab5c6b",
+            "a9e1826f0d3b4097b55d94f6059b9c19",
+            "3f1434df2ae44c6a813fdbcd536ceba1",
+            "7c83f0a51d62405998a1daf840cf8fbc",
+            "3c5482f9f86945b6a1ca565b996e6afe",
+            "a1c534924ac14e94b86c0896ef011bda",
+            "99bc3614faf543c99c77981c5a244e87",
+            "1b99a4ada8ec41bbab8bf652ef90f199",
+            "5b623b4e7c7d44098d0e731a1f1a650f",
+            "16c50d9feaa44f8b8c8b05aff6f8d773",
+            "295c22961e5846f3a674c306ccf77919",
+            "a2d8e18039a142e98ec0192bb419b311",
+            "3ae163fe2441420cadda46c45c8b0788",
+            "abf1d33e12ab44a183abdfc920377d1f",
+            "65831e7d830a4aa6959343b3203646b9",
+            "71f96c798571403f8d24def284d976dd",
+            "52ccd2b56733499ab1704b3086ebf5f3",
+            "64fd5c025a0a493abe4d0e020fe7777b",
+            "ba0d9249f4c249dfb18f5a6b45b50b6a",
+            "719018907f3944cab4a3678c10e6a317",
+            "b3c4f8134a364dd6bd37d41943b8496f",
+            "0ad0872dac514827b2cf26bec2338efb",
+            "cba481c9f6b2416da3424f347c72cdc6",
+            "0b92b5b3b0384913a6aa3cd592a0bc54",
+            "5bd85517e14a4df0bc7051479e6de15c",
+            "3abd3365cd104e419626427b5de97278",
+            "87969f6fc6ee41208e8cecf1ff646b67",
+            "0f96976f61bf4ff29edac10115d1eedd",
+            "de5793113feb44e2996edf83325dbe6a"
           ]
         },
-        "outputId": "e87ca199-09ab-44b1-91fa-a9d8d6745073"
+        "outputId": "14221c65-2503-4959-80e8-608a8ffa504f"
       },
       "source": [
         "from datasets import load_dataset\n",
@@ -5281,13 +3378,13 @@
         "dataset = load_dataset(\"rotten_tomatoes\")\n",
         "dataset.num_rows"
       ],
-      "execution_count": null,
+      "execution_count": 4,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "01d575495f3449f1bb900454d851de7c",
+              "model_id": "c3aa99f89b76454c96a862454a359f6b",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5310,7 +3407,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "cc11d16e71a44c18b6428d1a2b63a235",
+              "model_id": "601e07e7e60e440aab0792c52c4e59eb",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5341,7 +3438,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "64ae0f4ffde9471f8444d3e648264b49",
+              "model_id": "278d86f375a2411c95ffa67ab3ead553",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5364,7 +3461,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "1ba1ec2da5804fc892c0aa0af0f423e5",
+              "model_id": "a1c534924ac14e94b86c0896ef011bda",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5387,7 +3484,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "2c003880a36c497696f671a51aaff0fc",
+              "model_id": "abf1d33e12ab44a183abdfc920377d1f",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5410,7 +3507,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "622ea4fedef64cc7b52ffc8b5ceb9d6d",
+              "model_id": "0ad0872dac514827b2cf26bec2338efb",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5439,7 +3536,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 2
+          "execution_count": 4
         }
       ]
     },
@@ -5459,12 +3556,12 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "ffa8433c-fc9c-45d8-eec5-a3d50f443743"
+        "outputId": "96bad6a4-0fe5-4f0a-a48f-0e79e06e6430"
       },
       "source": [
         "dataset['train'][0]"
       ],
-      "execution_count": null,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -5477,7 +3574,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 3
+          "execution_count": 5
         }
       ]
     },
@@ -5498,49 +3595,49 @@
           "base_uri": "https://localhost:8080/",
           "height": 269,
           "referenced_widgets": [
-            "009d19f5f15c4bda9cdd53836c82862a",
-            "f22591f217ff4031a679408ddcb46fe1",
-            "5869a3def38a4151bbc773a54d4db7b7",
-            "2c1f43e42c61427db36ec54356995056",
-            "f6ec6b0c18674e07bb8d87e2501c3271",
-            "85f9fd7665994b5da7662c47f6ef06a1",
-            "636c0fd99cc446c59826cced2af43226",
-            "1ed334588d51498baa513830262550a9",
-            "afc06ccf7f354d269442f1b29f6e2110",
-            "570a871cd31d401f8f082bd824557624",
-            "54e9d5617f724e1eb72b42782ad5f25c",
-            "f902898ae06346d095a422e2c520fce4",
-            "7615117334cc4309a52d8990b754cf23",
-            "d4cb0eef066e4fa2900b182dcf959a8f",
-            "3b1942afe4b744c9b66a7cfae8fd6e88",
-            "62ea91e8d13640788d6981875854c293",
-            "9a1311fee05c4180887869f5169d65f9",
-            "b53d1c6ec19c4cb7a94fd77727cb8b6e",
-            "4bebecbd7b4940e59690bfdd106efbf8",
-            "967ce96c8388492ca4ef18716224f9db",
-            "970f50c3644c47fb9ecff569b11cf21a",
-            "dd3108dd9e6141368700ab6f457e101b",
-            "869afef38f534b4d967fb82f668a0de2",
-            "065feaaac34c45698d07a6440ba855ec",
-            "2d2c2526d5884c5b95b144ed77e233b4",
-            "0505ed1ff29b4ea188cadfbbb57b58f3",
-            "b34fc80d92ea406ca0c9fd07f073fef9",
-            "1b065a0884544683b6cf6a247a626de2",
-            "cb020c297ccd4e179fa1f43ca0c2da64",
-            "9d213c524a0d4c608cf2a6d0c2aa21d4",
-            "6d8d4798ffdd40558ff722af0fea0a66",
-            "9b17e5e89e034fb5a721bd7efc74d426",
-            "3528a71234c6481aa69ba04072d939ee",
-            "eddce3a8e86c42b9b6a03181f4bf89e4",
-            "a5927dbeb9c74ed7a14d5920959dfd2b",
-            "763977423f4d438aa831814cac9d87d3",
-            "de87322ae9b54083820c4f53944de951",
-            "e6ac685876da40e9bc0765fd0d3ecc20",
-            "91b13af76e314caca68161e94bb7a4fe",
-            "2b7b5e6d11ef4702aee411d9c04c16e8"
+            "4a8329b6f8ff4802bd9d6c437b84e329",
+            "770c47502de04f059dc53b1cca002c9b",
+            "9f8d42ec09d84646a786a2547906846f",
+            "e33c206636b34e859d3c0681e3e0c558",
+            "d8fb334f7a2144ccbd5ab04efd441e41",
+            "51ac628f4f544c5dbf985accba1134e8",
+            "f49b9dfff9e34b71b081fd5f17954f5d",
+            "2706662c519949119140b11124f14ebb",
+            "641e2f656b0849628c0511b8d0e00236",
+            "ad68cbc068e54ac4a3db94ef4ffacaf9",
+            "c1317b7e87344bf28299497a4f616b4d",
+            "328d5387c5024554a9e0e3c3e3c00a64",
+            "d4d48e22fcc54caba645e9bb6204d102",
+            "b25a3e07181149798938e93af2ac9c82",
+            "ab6436322cbf49e18d2e31b64fbee854",
+            "9e14ab86471243cc97d19ab8c5f878eb",
+            "8d73e2f87c9a4f459120c52c2c13b99b",
+            "904dab0f997f4d528ec29b03cfa3f9ce",
+            "7caf3511f7a8480f9231d0ebc18ad464",
+            "ce3dc2613747408e988663b2d7c0fca7",
+            "818ac8c0164c44dcb75367ba66c403eb",
+            "d744cb6c14e74631a9b682663c3c48eb",
+            "c668e22e3fa44822b2348c66125e52eb",
+            "5a58d2e05ab547178bde46f38b3f2508",
+            "a37a7a7a2f8d4d1da71fa62a09cba0f8",
+            "2a64f468682649338d5c5e39797d4619",
+            "f1d344a1829d48c0b869c928874017be",
+            "8d239eb5fdeb4c37ad7f8b904eda66d7",
+            "fbead18c6de84e6c999c57570edb4660",
+            "30a0b7c3b3a54806ba701d660b0a1e8c",
+            "796e808439a8450299b51d524f9316f8",
+            "1a20bf61207d45ddb325719d4b7c9148",
+            "d7259df55724410398d772e596492785",
+            "102db28574914068945ac5a21a881272",
+            "3012236fd9a645dc83acc79fc18740a6",
+            "990fdec67b3e476bb857b3a29ee40a18",
+            "c2380b3d6ef649b4a746fd7d2987a53f",
+            "74dc804ece004364b02afaa0f2e445e6",
+            "662f444e5b5d406ba6977c3ca2ac3140",
+            "5fa022229fc3451e8f4ca55d99f5f399"
           ]
         },
-        "outputId": "77053d1b-5c8c-4880-af5c-a3ee00400268"
+        "outputId": "82f215ff-06f9-405a-99cb-6081053c881b"
       },
       "source": [
         "from transformers import RobertaTokenizer\n",
@@ -5558,13 +3655,13 @@
         "# Transform to pytorch tensors and only output the required columns\n",
         "dataset.set_format(type=\"torch\", columns=[\"input_ids\", \"attention_mask\", \"labels\"])"
       ],
-      "execution_count": null,
+      "execution_count": 6,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "009d19f5f15c4bda9cdd53836c82862a",
+              "model_id": "4a8329b6f8ff4802bd9d6c437b84e329",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5587,7 +3684,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "afc06ccf7f354d269442f1b29f6e2110",
+              "model_id": "641e2f656b0849628c0511b8d0e00236",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5610,7 +3707,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "9a1311fee05c4180887869f5169d65f9",
+              "model_id": "8d73e2f87c9a4f459120c52c2c13b99b",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5633,7 +3730,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "2d2c2526d5884c5b95b144ed77e233b4",
+              "model_id": "a37a7a7a2f8d4d1da71fa62a09cba0f8",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5656,7 +3753,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "3528a71234c6481aa69ba04072d939ee",
+              "model_id": "d7259df55724410398d772e596492785",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5705,25 +3802,25 @@
           "base_uri": "https://localhost:8080/",
           "height": 230,
           "referenced_widgets": [
-            "29dc93819e9740988234a18653b0eab0",
-            "531905d0c4ba41c88d859a8dc7a6633b",
-            "51a65ebcf55e445695b82a78cf10915c",
-            "353816c214cb473392ae4b297834da25",
-            "1116f49f50984fa58ce0094061f1b1d4",
-            "0151f5a2fd434c7f85b6566eec890d3e",
-            "0de7cb0f177e4c3e90056e86154a72af",
-            "5763556e884b4501bfc2a74f8ba63250",
-            "43218c9674f041428625ea02f3ca0de6",
-            "4cba233614e14c45aed4eb1faa9283fa",
-            "5b3324b8f8c041e0b358c7b8077a134e",
-            "4e3bafc786f6417caaa8c788c07c27a2",
-            "669ee06c6687491eb2e9d331129406f8",
-            "357ec0469865467498ea6145441d71ce",
-            "26640724c26340e3a49b983a7385d569",
-            "697b9074a0a44e66850be5b9da708d03"
+            "9da723c91128430aaf0de657b5d78614",
+            "fcaa1a0b279f44a383b890e21e7fab98",
+            "c6f0b71cd4044a5eb4a3807b1aabb2a3",
+            "5c77f543bafe4e40a0ef7fdcc46ca840",
+            "5294399a5b17497685ce84d755786427",
+            "42ae0acfec4644bfb39110c2d220da35",
+            "377bfbd756034a638a79f962e3002b55",
+            "4207ecdfbb8d4be7ab8a37f7025e8ed0",
+            "64f27e101aeb4b66aae1f280401adcc8",
+            "243fc2fe7d9d492cb95e7e84da403a27",
+            "14e8e514752c43c5be0613a90342ec28",
+            "b60924467c084300bc84b3e2454a92e4",
+            "2963c36cb8d747a2890dc5d1b287d345",
+            "bf307055977f473e99b94a90c95f8269",
+            "41a7a6711efb495fbdca9b40ec2d0a59",
+            "29819fe095904d3e8d15522c7a9ef416"
           ]
         },
-        "outputId": "0c064347-4efb-41bc-a217-f5518d180dfd"
+        "outputId": "747d347b-d7e6-443d-ebab-b887b493db23"
       },
       "source": [
         "from transformers import RobertaConfig, RobertaModelWithHeads\n",
@@ -5738,13 +3835,13 @@
         "    config=config,\n",
         ")"
       ],
-      "execution_count": null,
+      "execution_count": 7,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "29dc93819e9740988234a18653b0eab0",
+              "model_id": "9da723c91128430aaf0de657b5d78614",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5767,7 +3864,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "43218c9674f041428625ea02f3ca0de6",
+              "model_id": "64f27e101aeb4b66aae1f280401adcc8",
               "version_minor": 0,
               "version_major": 2
             },
@@ -5790,7 +3887,7 @@
           "output_type": "stream",
           "text": [
             "Some weights of the model checkpoint at roberta-base were not used when initializing RobertaModelWithHeads: ['lm_head.bias', 'lm_head.dense.weight', 'lm_head.dense.bias', 'lm_head.layer_norm.weight', 'lm_head.layer_norm.bias', 'lm_head.decoder.weight']\n",
-            "- This IS expected if you are initializing RobertaModelWithHeads from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPretraining model).\n",
+            "- This IS expected if you are initializing RobertaModelWithHeads from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
             "- This IS NOT expected if you are initializing RobertaModelWithHeads from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
             "Some weights of RobertaModelWithHeads were not initialized from the model checkpoint at roberta-base and are newly initialized: ['roberta.embeddings.position_ids']\n",
             "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
@@ -5828,7 +3925,7 @@
         "# Activate the adapter\n",
         "model.train_adapter(\"rotten_tomatoes\")"
       ],
-      "execution_count": null,
+      "execution_count": 8,
       "outputs": []
     },
     {
@@ -5859,6 +3956,8 @@
         "    logging_steps=200,\n",
         "    output_dir=\"./training_output\",\n",
         "    overwrite_output_dir=True,\n",
+        "    # The next line is important to ensure the dataset labels are properly passed to the model\n",
+        "    remove_unused_columns=False,\n",
         ")\n",
         "\n",
         "def compute_accuracy(p: EvalPrediction):\n",
@@ -5873,7 +3972,7 @@
         "    compute_metrics=compute_accuracy,\n",
         ")"
       ],
-      "execution_count": null,
+      "execution_count": 9,
       "outputs": []
     },
     {
@@ -5891,255 +3990,104 @@
         "id": "UcZMwiJ_KDdP",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 592,
-          "referenced_widgets": [
-            "4918bcb45e494ec0a16fa4cd68072888",
-            "d998e81fb7324ec5aec0afc6ccea6fc3",
-            "61da2ccc4b2d4a568ddde68877e3ffc5",
-            "c99c80753ebf47fab7eed74f4be56972",
-            "2338b529b7f843a7a5687fa36f128a3f",
-            "706d9a3c75d64238a3ffa7241f8f1f64",
-            "c299444f0aac432297d5131daa85ea53",
-            "d9045f5f8f24420f99c65efde4db7864",
-            "8d188fe6e5474e11a810d6827c8796c8",
-            "f73c9f049b124e5d96aa9c80f9be1006",
-            "2d16e52ba07a496096abee747df710f7",
-            "720faf02b77a4ecd97fbb9de08257157",
-            "18fc828f494d46cfad6a1bcf35416d96",
-            "9dfa41512b8b43fba84c82aceab82137",
-            "340da1da961f4b0c835bd531bba517ae",
-            "11389bbfd8df401bad4fdedd675d27da",
-            "3bed0b6219b248bd9ea6e4d3c9728fa9",
-            "1ca3f4c282394e23aefeb02c13e571cc",
-            "442b1806d8f542bc9d4afda8b794e724",
-            "a1a9a37cd2514188b347cc40039ae9ce",
-            "0ced897cef3b4344a993b004c6138a19",
-            "c6680b04efd3469ab12e17cfe1b1dfc2",
-            "d4e9584a099341fc8df5626fc9432597",
-            "15fc7c1e00ec4eb9a8c4ce1ec835aeb2",
-            "66e3df94b86a4513a420e9b537686255",
-            "ccc4a24f08ef40668411940cdc3b4cf6",
-            "43b0da110e454c23919ff012cc0b93df",
-            "9c74a88e05c64441846205ec2519fb4a",
-            "eebcc6a327fb496a8917e49fee8e8122",
-            "0ad8ed8b44eb4870821f29ab498de5d2",
-            "05f3a5caef254f238f5ada346946836f",
-            "4464a13d4e714633af2e5f6b208f4380",
-            "dd0f4e1230cb4421a3209c0e095669ee",
-            "491fb058b02b4d67b771b4b86c5a679d",
-            "7319072116914089988acf05a220e3e8",
-            "63ed9256615d4229975dbdf7a168da3b",
-            "250f16d7d77f464db0bb524c9ec9ab20",
-            "68bbd81e25904c05aab55e0ced718fb0",
-            "be8260cab646476e871487abb32622bb",
-            "d1b6a0dd295c453b8a1b24e3d73d6a0f",
-            "eff9695c671349e8a9ad424702663361",
-            "5b004f46dc554672b85ceebc427c0504",
-            "118fd7c5ec8c4737b42146f592bb0932",
-            "93b9a59513594577a90f4478c3da5bf2",
-            "51cda8efc56c49de91adb8343c402e86",
-            "47336d84a1394a218b9120e765e52a16",
-            "2ad5090f718f43f6a8504bc43630fdcc",
-            "2a16cd20241e442fbc13b7b375a99b86",
-            "3095d71f26594d70aea89227e45aefce",
-            "a68de4ce160148458ea595c24fea7643",
-            "719659e3d8fd48b1b038620daf7760e6",
-            "c862f3e51bb6490f8237655378d00dd6",
-            "9e18cf85ee0f41b3ab3e45e91fb69417",
-            "1065aff8cdb2406ab60ae8e65065472b",
-            "2a5c907e1ca544f3b041be19615fb66d",
-            "401557a225ab43f4b16fa00c50b4d717"
-          ]
+          "height": 401
         },
-        "outputId": "712c80ab-1897-49c4-8158-431c4c15f183"
+        "outputId": "c85848ef-a396-42ea-fa5e-0df97f593902"
       },
       "source": [
         "trainer.train()"
       ],
-      "execution_count": null,
+      "execution_count": 10,
       "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "4918bcb45e494ec0a16fa4cd68072888",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "HBox(children=(FloatProgress(value=0.0, description='Epoch', max=6.0, style=ProgressStyle(description_width='i…"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "8d188fe6e5474e11a810d6827c8796c8",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "HBox(children=(FloatProgress(value=0.0, description='Iteration', max=267.0, style=ProgressStyle(description_wi…"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        },
         {
           "output_type": "stream",
           "text": [
-            "/usr/local/lib/python3.6/dist-packages/datasets/arrow_dataset.py:847: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:141.)\n",
+            "/usr/local/lib/python3.6/dist-packages/datasets/arrow_dataset.py:850: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:141.)\n",
             "  return torch.tensor(x, **format_kwargs)\n"
           ],
           "name": "stderr"
         },
         {
-          "output_type": "stream",
-          "text": [
-            "{'loss': 0.4757337951660156, 'learning_rate': 8.75156054931336e-05, 'epoch': 0.7490636704119851, 'total_flos': 390226384896000, 'step': 200}\n",
-            "\n"
-          ],
-          "name": "stdout"
-        },
-        {
           "output_type": "display_data",
           "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "3bed0b6219b248bd9ea6e4d3c9728fa9",
-              "version_minor": 0,
-              "version_major": 2
-            },
+            "text/html": [
+              "\n",
+              "    <div>\n",
+              "        <style>\n",
+              "            /* Turns off some styling */\n",
+              "            progress {\n",
+              "                /* gets rid of default border in Firefox and Opera. */\n",
+              "                border: none;\n",
+              "                /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+              "                background-size: auto;\n",
+              "            }\n",
+              "        </style>\n",
+              "      \n",
+              "      <progress value='1602' max='1602' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+              "      [1602/1602 09:14, Epoch 6/6]\n",
+              "    </div>\n",
+              "    <table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: left;\">\n",
+              "      <th>Step</th>\n",
+              "      <th>Training Loss</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <td>200</td>\n",
+              "      <td>0.469576</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>400</td>\n",
+              "      <td>0.313648</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>600</td>\n",
+              "      <td>0.284003</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>800</td>\n",
+              "      <td>0.269178</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>1000</td>\n",
+              "      <td>0.246140</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>1200</td>\n",
+              "      <td>0.238821</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>1400</td>\n",
+              "      <td>0.228444</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>1600</td>\n",
+              "      <td>0.218775</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table><p>"
+            ],
             "text/plain": [
-              "HBox(children=(FloatProgress(value=0.0, description='Iteration', max=267.0, style=ProgressStyle(description_wi…"
+              "<IPython.core.display.HTML object>"
             ]
           },
           "metadata": {
             "tags": []
           }
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "{'loss': 0.3162423706054687, 'learning_rate': 7.503121098626716e-05, 'epoch': 1.4981273408239701, 'total_flos': 779599149575040, 'step': 400}\n",
-            "\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "66e3df94b86a4513a420e9b537686255",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "HBox(children=(FloatProgress(value=0.0, description='Iteration', max=267.0, style=ProgressStyle(description_wi…"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "{'loss': 0.2839324951171875, 'learning_rate': 6.254681647940075e-05, 'epoch': 2.247191011235955, 'total_flos': 1168971914254080, 'step': 600}\n",
-            "{'loss': 0.27122039794921876, 'learning_rate': 5.006242197253434e-05, 'epoch': 2.9962546816479403, 'total_flos': 1559198299150080, 'step': 800}\n",
-            "\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "dd0f4e1230cb4421a3209c0e095669ee",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "HBox(children=(FloatProgress(value=0.0, description='Iteration', max=267.0, style=ProgressStyle(description_wi…"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "{'loss': 0.24722808837890625, 'learning_rate': 3.7578027465667915e-05, 'epoch': 3.7453183520599254, 'total_flos': 1948571063829120, 'step': 1000}\n",
-            "\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "eff9695c671349e8a9ad424702663361",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "HBox(children=(FloatProgress(value=0.0, description='Iteration', max=267.0, style=ProgressStyle(description_wi…"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "{'loss': 0.235828857421875, 'learning_rate': 2.50936329588015e-05, 'epoch': 4.49438202247191, 'total_flos': 2337943828508160, 'step': 1200}\n",
-            "\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "3095d71f26594d70aea89227e45aefce",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "HBox(children=(FloatProgress(value=0.0, description='Iteration', max=267.0, style=ProgressStyle(description_wi…"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "{'loss': 0.22592971801757813, 'learning_rate': 1.2609238451935081e-05, 'epoch': 5.2434456928838955, 'total_flos': 2727316593187200, 'step': 1400}\n",
-            "{'loss': 0.21846298217773438, 'learning_rate': 1.2484394506866418e-07, 'epoch': 5.992509363295881, 'total_flos': 3117542978083200, 'step': 1600}\n",
-            "\n",
-            "\n"
-          ],
-          "name": "stdout"
         },
         {
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "TrainOutput(global_step=1602, training_loss=0.2841355875041452)"
+              "TrainOutput(global_step=1602, training_loss=0.2833864400151666)"
             ]
           },
           "metadata": {
             "tags": []
           },
-          "execution_count": 8
+          "execution_count": 10
         }
       ]
     },
@@ -6158,35 +4106,38 @@
         "id": "9PgHWEhsYeMv",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 159,
-          "referenced_widgets": [
-            "15f9d1b026b24e119b1428d4e9eb3651",
-            "b97b91efee334b9380886ed3366f2ec1",
-            "06b961c8e115456490a5e6a430effc71",
-            "6c37ed5907a74be1a59a518136ff11ac",
-            "dbdc0506e5e741c5a77b5eaddca7ebe6",
-            "50191dee959e4fec89b1011506b3e39c",
-            "d68c11a186fd491fa35f214592da7a3b",
-            "a82c817d8ca54fb4ba711fae4da2d3f5"
-          ]
+          "height": 55
         },
-        "outputId": "82c9b4d8-283e-4c20-ca5d-1ba845d15f4b"
+        "outputId": "4d6ec6d0-a58d-4867-f9af-72ba6d899ff7"
       },
       "source": [
         "trainer.evaluate()"
       ],
-      "execution_count": null,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "15f9d1b026b24e119b1428d4e9eb3651",
-              "version_minor": 0,
-              "version_major": 2
-            },
+            "text/html": [
+              "\n",
+              "    <div>\n",
+              "        <style>\n",
+              "            /* Turns off some styling */\n",
+              "            progress {\n",
+              "                /* gets rid of default border in Firefox and Opera. */\n",
+              "                border: none;\n",
+              "                /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+              "                background-size: auto;\n",
+              "            }\n",
+              "        </style>\n",
+              "      \n",
+              "      <progress value='34' max='34' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+              "      [34/34 00:05]\n",
+              "    </div>\n",
+              "    "
+            ],
             "text/plain": [
-              "HBox(children=(FloatProgress(value=0.0, description='Evaluation', max=34.0, style=ProgressStyle(description_wi…"
+              "<IPython.core.display.HTML object>"
             ]
           },
           "metadata": {
@@ -6194,27 +4145,16 @@
           }
         },
         {
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "{'eval_loss': 0.29718441593043127, 'eval_acc': 0.8855534709193246, 'epoch': 6.0, 'total_flos': 3120591621715200, 'step': 1602}\n"
-          ],
-          "name": "stdout"
-        },
-        {
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "{'epoch': 6.0,\n",
-              " 'eval_acc': 0.8855534709193246,\n",
-              " 'eval_loss': 0.29718441593043127,\n",
-              " 'total_flos': 3120591621715200}"
+              "{'epoch': 6.0, 'eval_acc': 0.8874296435272045, 'eval_loss': 0.2794782519340515}"
             ]
           },
           "metadata": {
             "tags": []
           },
-          "execution_count": 9
+          "execution_count": 11
         }
       ]
     },
@@ -6234,7 +4174,7 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "7d93d02b-58d3-4dcf-dad4-93fe091b1e0b"
+        "outputId": "d8292cbe-4e43-4303-cd38-ab6725646b7c"
       },
       "source": [
         " from transformers import TextClassificationPipeline\n",
@@ -6243,19 +4183,19 @@
         "\n",
         "classifier(\"This is awesome!\")"
       ],
-      "execution_count": null,
+      "execution_count": 12,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "[{'label': '👍', 'score': 0.9945221543312073}]"
+              "[{'label': 'LABEL_1', 'score': 0.9894435405731201}]"
             ]
           },
           "metadata": {
             "tags": []
           },
-          "execution_count": 10
+          "execution_count": 12
         }
       ]
     },
@@ -6275,23 +4215,23 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "136d56e7-6c95-4d19-a880-d33576cc8368"
+        "outputId": "172395dd-4076-4045-b90d-9c7c817524c3"
       },
       "source": [
         "model.save_adapter(\"./final_adapter\", \"rotten_tomatoes\")\n",
         "\n",
         "!ls -lh final_adapter"
       ],
-      "execution_count": null,
+      "execution_count": 13,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
             "total 5.8M\n",
-            "-rw-r--r-- 1 root root  631 Nov 16 10:53 adapter_config.json\n",
-            "-rw-r--r-- 1 root root  344 Nov 16 10:53 head_config.json\n",
-            "-rw-r--r-- 1 root root 3.5M Nov 16 10:53 pytorch_adapter.bin\n",
-            "-rw-r--r-- 1 root root 2.3M Nov 16 10:53 pytorch_model_head.bin\n"
+            "-rw-r--r-- 1 root root  631 Dec 15 16:57 adapter_config.json\n",
+            "-rw-r--r-- 1 root root  344 Dec 15 16:57 head_config.json\n",
+            "-rw-r--r-- 1 root root 3.5M Dec 15 16:57 pytorch_adapter.bin\n",
+            "-rw-r--r-- 1 root root 2.3M Dec 15 16:57 pytorch_model_head.bin\n"
           ],
           "name": "stdout"
         }

--- a/notebooks/01_Adapter_Training.ipynb
+++ b/notebooks/01_Adapter_Training.ipynb
@@ -15,7 +15,7 @@
     "accelerator": "GPU",
     "widgets": {
       "application/vnd.jupyter.widget-state+json": {
-        "c3aa99f89b76454c96a862454a359f6b": {
+        "3a9b4ec9a3e748c7a21fe3cda7fedd8c": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -27,15 +27,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_7487c6cc822d491597a3aada5af8e454",
+            "layout": "IPY_MODEL_d32b921e161e49feaa09de4b371753f2",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_c434f4813daf4dd699c553d2a6736e00",
-              "IPY_MODEL_f9f50a85c48b4d4786ac16836ef0e083"
+              "IPY_MODEL_8d07b853c60545bcaab48d3e45366138",
+              "IPY_MODEL_97a23288915a4a17bbecf24995907e9f"
             ]
           }
         },
-        "7487c6cc822d491597a3aada5af8e454": {
+        "d32b921e161e49feaa09de4b371753f2": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -86,12 +86,12 @@
             "left": null
           }
         },
-        "c434f4813daf4dd699c553d2a6736e00": {
+        "8d07b853c60545bcaab48d3e45366138": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_cb1ee710a1344fe8b0c817249fb51e3d",
+            "style": "IPY_MODEL_9f248795ccfb48ef8a29b4d1b52f8b8a",
             "_dom_classes": [],
             "description": "Downloading: ",
             "_model_name": "FloatProgressModel",
@@ -106,30 +106,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_adb199dacb9c4881be7ae6ffdd665b54"
+            "layout": "IPY_MODEL_cb6d5faa575a4a2fb33cdf714533e223"
           }
         },
-        "f9f50a85c48b4d4786ac16836ef0e083": {
+        "97a23288915a4a17bbecf24995907e9f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_643c34677a93499fa233e5f52649b0e0",
+            "style": "IPY_MODEL_de7ddc9b059e437f8e2d4bce3b6a032a",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 5.04k/? [00:00&lt;00:00, 5.34kB/s]",
+            "value": " 5.04k/? [00:00&lt;00:00, 7.22kB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_94832fd6f4f7419bac117598f804d1c6"
+            "layout": "IPY_MODEL_c0226a0682884615a15370865a9414b8"
           }
         },
-        "cb1ee710a1344fe8b0c817249fb51e3d": {
+        "9f248795ccfb48ef8a29b4d1b52f8b8a": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -144,7 +144,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "adb199dacb9c4881be7ae6ffdd665b54": {
+        "cb6d5faa575a4a2fb33cdf714533e223": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -195,7 +195,7 @@
             "left": null
           }
         },
-        "643c34677a93499fa233e5f52649b0e0": {
+        "de7ddc9b059e437f8e2d4bce3b6a032a": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -209,7 +209,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "94832fd6f4f7419bac117598f804d1c6": {
+        "c0226a0682884615a15370865a9414b8": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -260,7 +260,7 @@
             "left": null
           }
         },
-        "601e07e7e60e440aab0792c52c4e59eb": {
+        "89d542a0e85f4fbfaff2ffa617052bc6": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -272,15 +272,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_c472912011a6462088eeeb2baba50bf0",
+            "layout": "IPY_MODEL_447df269f40f45b19e6c46addb25fb3c",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_075ff4547bcd44e48ec9255ade034dcf",
-              "IPY_MODEL_f70900ce8da44d7b98ad436057e61a14"
+              "IPY_MODEL_1f6c85f8ae67454eaf5970a544087d07",
+              "IPY_MODEL_e394434dce9d4b42a5a2e98a8d93e69d"
             ]
           }
         },
-        "c472912011a6462088eeeb2baba50bf0": {
+        "447df269f40f45b19e6c46addb25fb3c": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -331,12 +331,12 @@
             "left": null
           }
         },
-        "075ff4547bcd44e48ec9255ade034dcf": {
+        "1f6c85f8ae67454eaf5970a544087d07": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_7adefdefdb0d4e3c89dea3f94355a22a",
+            "style": "IPY_MODEL_b0f931a617d44c359db0ec746ee7028f",
             "_dom_classes": [],
             "description": "Downloading: ",
             "_model_name": "FloatProgressModel",
@@ -351,30 +351,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_c23742b6f64a4896a929a663df319a07"
+            "layout": "IPY_MODEL_2c607118fe6143fca05ca60329050800"
           }
         },
-        "f70900ce8da44d7b98ad436057e61a14": {
+        "e394434dce9d4b42a5a2e98a8d93e69d": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_366d05764cdf4615840ca2a4882c714b",
+            "style": "IPY_MODEL_79dfc3aa220c4894b94e02c784d47d6b",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 1.88k/? [00:00&lt;00:00, 15.1kB/s]",
+            "value": " 1.88k/? [00:00&lt;00:00, 23.9kB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_d80a43cd09e74f6488953d0375f16630"
+            "layout": "IPY_MODEL_a8629ce41ef641cdb69fbbfc8a599a99"
           }
         },
-        "7adefdefdb0d4e3c89dea3f94355a22a": {
+        "b0f931a617d44c359db0ec746ee7028f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -389,7 +389,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "c23742b6f64a4896a929a663df319a07": {
+        "2c607118fe6143fca05ca60329050800": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -440,7 +440,7 @@
             "left": null
           }
         },
-        "366d05764cdf4615840ca2a4882c714b": {
+        "79dfc3aa220c4894b94e02c784d47d6b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -454,7 +454,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "d80a43cd09e74f6488953d0375f16630": {
+        "a8629ce41ef641cdb69fbbfc8a599a99": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -505,7 +505,7 @@
             "left": null
           }
         },
-        "278d86f375a2411c95ffa67ab3ead553": {
+        "0c1047a82d20482a98ae293269e5af98": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -517,15 +517,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_17c5f9d76aa143dd97b28bd022b65928",
+            "layout": "IPY_MODEL_1798b1a3e6f1471fa594b5286d139d8c",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_3a23fd2815db4a9e932d4b24730544cf",
-              "IPY_MODEL_d1fcae5dc5ae4c4ba3a88acfc2ab5c6b"
+              "IPY_MODEL_998d43a540124e65921b3370571fb286",
+              "IPY_MODEL_bc3376f518454e3c96d532845c51cf86"
             ]
           }
         },
-        "17c5f9d76aa143dd97b28bd022b65928": {
+        "1798b1a3e6f1471fa594b5286d139d8c": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -576,12 +576,12 @@
             "left": null
           }
         },
-        "3a23fd2815db4a9e932d4b24730544cf": {
+        "998d43a540124e65921b3370571fb286": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_a9e1826f0d3b4097b55d94f6059b9c19",
+            "style": "IPY_MODEL_609717db231447c9b151ae0761678d28",
             "_dom_classes": [],
             "description": "Downloading: 100%",
             "_model_name": "FloatProgressModel",
@@ -596,30 +596,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_3f1434df2ae44c6a813fdbcd536ceba1"
+            "layout": "IPY_MODEL_9d5910aea7c8439e8b545a73d5bca27a"
           }
         },
-        "d1fcae5dc5ae4c4ba3a88acfc2ab5c6b": {
+        "bc3376f518454e3c96d532845c51cf86": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_7c83f0a51d62405998a1daf840cf8fbc",
+            "style": "IPY_MODEL_2f967ca5a75e4071a50a9c8152f23491",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 488k/488k [00:00&lt;00:00, 3.82MB/s]",
+            "value": " 488k/488k [00:00&lt;00:00, 3.76MB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_3c5482f9f86945b6a1ca565b996e6afe"
+            "layout": "IPY_MODEL_b8bc66a38aab4722ac9d0931c9904bf7"
           }
         },
-        "a9e1826f0d3b4097b55d94f6059b9c19": {
+        "609717db231447c9b151ae0761678d28": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -634,7 +634,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "3f1434df2ae44c6a813fdbcd536ceba1": {
+        "9d5910aea7c8439e8b545a73d5bca27a": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -685,7 +685,7 @@
             "left": null
           }
         },
-        "7c83f0a51d62405998a1daf840cf8fbc": {
+        "2f967ca5a75e4071a50a9c8152f23491": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -699,7 +699,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "3c5482f9f86945b6a1ca565b996e6afe": {
+        "b8bc66a38aab4722ac9d0931c9904bf7": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -750,7 +750,7 @@
             "left": null
           }
         },
-        "a1c534924ac14e94b86c0896ef011bda": {
+        "cd254feed6184bc7aa08b4a17062dd03": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -762,15 +762,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_99bc3614faf543c99c77981c5a244e87",
+            "layout": "IPY_MODEL_2073764124464e97964d23233335539e",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_1b99a4ada8ec41bbab8bf652ef90f199",
-              "IPY_MODEL_5b623b4e7c7d44098d0e731a1f1a650f"
+              "IPY_MODEL_25f3fee587334dab9e3e11be00e5b584",
+              "IPY_MODEL_0b390c2b77a9488289f7f5fe7d11fd16"
             ]
           }
         },
-        "99bc3614faf543c99c77981c5a244e87": {
+        "2073764124464e97964d23233335539e": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -821,12 +821,12 @@
             "left": null
           }
         },
-        "1b99a4ada8ec41bbab8bf652ef90f199": {
+        "25f3fee587334dab9e3e11be00e5b584": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_16c50d9feaa44f8b8c8b05aff6f8d773",
+            "style": "IPY_MODEL_cd667d66c2184a5a8747b903d0ee426e",
             "_dom_classes": [],
             "description": "",
             "_model_name": "FloatProgressModel",
@@ -841,30 +841,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_295c22961e5846f3a674c306ccf77919"
+            "layout": "IPY_MODEL_3c5da4b734a04d658da3610e7b07aba8"
           }
         },
-        "5b623b4e7c7d44098d0e731a1f1a650f": {
+        "0b390c2b77a9488289f7f5fe7d11fd16": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_a2d8e18039a142e98ec0192bb419b311",
+            "style": "IPY_MODEL_6ad6848c3a62406eb63fa2aafba0ae9a",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 8530/0 [00:00&lt;00:00, 30847.46 examples/s]",
+            "value": " 8530/0 [00:00&lt;00:00, 33689.79 examples/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_3ae163fe2441420cadda46c45c8b0788"
+            "layout": "IPY_MODEL_0ef74a3d0b7a414a8d8ac3855624a6e8"
           }
         },
-        "16c50d9feaa44f8b8c8b05aff6f8d773": {
+        "cd667d66c2184a5a8747b903d0ee426e": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -879,7 +879,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "295c22961e5846f3a674c306ccf77919": {
+        "3c5da4b734a04d658da3610e7b07aba8": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -930,7 +930,7 @@
             "left": null
           }
         },
-        "a2d8e18039a142e98ec0192bb419b311": {
+        "6ad6848c3a62406eb63fa2aafba0ae9a": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -944,7 +944,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "3ae163fe2441420cadda46c45c8b0788": {
+        "0ef74a3d0b7a414a8d8ac3855624a6e8": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -995,7 +995,7 @@
             "left": null
           }
         },
-        "abf1d33e12ab44a183abdfc920377d1f": {
+        "0049be330f83480bb2374d9433f380f2": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -1007,15 +1007,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_65831e7d830a4aa6959343b3203646b9",
+            "layout": "IPY_MODEL_19de841f95574870afabe05997fa0c0e",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_71f96c798571403f8d24def284d976dd",
-              "IPY_MODEL_52ccd2b56733499ab1704b3086ebf5f3"
+              "IPY_MODEL_1b24a2cae2774e32ac78026d659143cd",
+              "IPY_MODEL_06e17d538f2945d0b42c09ebad28ad58"
             ]
           }
         },
-        "65831e7d830a4aa6959343b3203646b9": {
+        "19de841f95574870afabe05997fa0c0e": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1066,12 +1066,12 @@
             "left": null
           }
         },
-        "71f96c798571403f8d24def284d976dd": {
+        "1b24a2cae2774e32ac78026d659143cd": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_64fd5c025a0a493abe4d0e020fe7777b",
+            "style": "IPY_MODEL_c51a4a10d27e45e5a17a04fd2108eee5",
             "_dom_classes": [],
             "description": "",
             "_model_name": "FloatProgressModel",
@@ -1086,30 +1086,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_ba0d9249f4c249dfb18f5a6b45b50b6a"
+            "layout": "IPY_MODEL_7f391d99245645c7815bdd0ca552e029"
           }
         },
-        "52ccd2b56733499ab1704b3086ebf5f3": {
+        "06e17d538f2945d0b42c09ebad28ad58": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_719018907f3944cab4a3678c10e6a317",
+            "style": "IPY_MODEL_fa3e63d18e2645559e74d63013362bb6",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 1066/0 [00:00&lt;00:00, 16841.68 examples/s]",
+            "value": " 1066/0 [00:00&lt;00:00, 17132.86 examples/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_b3c4f8134a364dd6bd37d41943b8496f"
+            "layout": "IPY_MODEL_19b54ac29440422caa8272418589d181"
           }
         },
-        "64fd5c025a0a493abe4d0e020fe7777b": {
+        "c51a4a10d27e45e5a17a04fd2108eee5": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -1124,7 +1124,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "ba0d9249f4c249dfb18f5a6b45b50b6a": {
+        "7f391d99245645c7815bdd0ca552e029": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1175,7 +1175,7 @@
             "left": null
           }
         },
-        "719018907f3944cab4a3678c10e6a317": {
+        "fa3e63d18e2645559e74d63013362bb6": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -1189,7 +1189,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "b3c4f8134a364dd6bd37d41943b8496f": {
+        "19b54ac29440422caa8272418589d181": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1240,7 +1240,7 @@
             "left": null
           }
         },
-        "0ad0872dac514827b2cf26bec2338efb": {
+        "e0613dc56e884e93a5a200c7c48f1ee1": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -1252,15 +1252,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_cba481c9f6b2416da3424f347c72cdc6",
+            "layout": "IPY_MODEL_ec28ae3ce7334732b39a70b5872285cb",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_0b92b5b3b0384913a6aa3cd592a0bc54",
-              "IPY_MODEL_5bd85517e14a4df0bc7051479e6de15c"
+              "IPY_MODEL_3cc2b4ff25e24271913f689f7c096d1b",
+              "IPY_MODEL_3a8fd5305d6447c1b49c29429ebd6e89"
             ]
           }
         },
-        "cba481c9f6b2416da3424f347c72cdc6": {
+        "ec28ae3ce7334732b39a70b5872285cb": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1311,12 +1311,12 @@
             "left": null
           }
         },
-        "0b92b5b3b0384913a6aa3cd592a0bc54": {
+        "3cc2b4ff25e24271913f689f7c096d1b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_3abd3365cd104e419626427b5de97278",
+            "style": "IPY_MODEL_fdc0603de2a64c5abf7ffdd0bb1a2bf2",
             "_dom_classes": [],
             "description": "",
             "_model_name": "FloatProgressModel",
@@ -1331,30 +1331,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_87969f6fc6ee41208e8cecf1ff646b67"
+            "layout": "IPY_MODEL_d4bdf3213e8f43c8b00f7e3c993aa4a3"
           }
         },
-        "5bd85517e14a4df0bc7051479e6de15c": {
+        "3a8fd5305d6447c1b49c29429ebd6e89": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_0f96976f61bf4ff29edac10115d1eedd",
+            "style": "IPY_MODEL_5caf1a4fbd4d49eda2f786ce4f485bbb",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 1066/0 [00:00&lt;00:00, 12622.25 examples/s]",
+            "value": " 1066/0 [00:00&lt;00:00, 16433.92 examples/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_de5793113feb44e2996edf83325dbe6a"
+            "layout": "IPY_MODEL_9a4deb0013714533a41c340461fa40a8"
           }
         },
-        "3abd3365cd104e419626427b5de97278": {
+        "fdc0603de2a64c5abf7ffdd0bb1a2bf2": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -1369,7 +1369,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "87969f6fc6ee41208e8cecf1ff646b67": {
+        "d4bdf3213e8f43c8b00f7e3c993aa4a3": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1420,7 +1420,7 @@
             "left": null
           }
         },
-        "0f96976f61bf4ff29edac10115d1eedd": {
+        "5caf1a4fbd4d49eda2f786ce4f485bbb": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -1434,7 +1434,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "de5793113feb44e2996edf83325dbe6a": {
+        "9a4deb0013714533a41c340461fa40a8": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1485,7 +1485,7 @@
             "left": null
           }
         },
-        "4a8329b6f8ff4802bd9d6c437b84e329": {
+        "eaa479faec154441b91b4540af762ef1": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -1497,15 +1497,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_770c47502de04f059dc53b1cca002c9b",
+            "layout": "IPY_MODEL_924af57eb418449a8a2aa5e64ddd3169",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_9f8d42ec09d84646a786a2547906846f",
-              "IPY_MODEL_e33c206636b34e859d3c0681e3e0c558"
+              "IPY_MODEL_2295fe241e3945aaa61886ad9174dd99",
+              "IPY_MODEL_06e2351cd4034920af3000edf3bc8ccc"
             ]
           }
         },
-        "770c47502de04f059dc53b1cca002c9b": {
+        "924af57eb418449a8a2aa5e64ddd3169": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1556,12 +1556,12 @@
             "left": null
           }
         },
-        "9f8d42ec09d84646a786a2547906846f": {
+        "2295fe241e3945aaa61886ad9174dd99": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_d8fb334f7a2144ccbd5ab04efd441e41",
+            "style": "IPY_MODEL_51e864e3295d46bb900f6b9405e20a93",
             "_dom_classes": [],
             "description": "Downloading: 100%",
             "_model_name": "FloatProgressModel",
@@ -1576,30 +1576,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_51ac628f4f544c5dbf985accba1134e8"
+            "layout": "IPY_MODEL_b2e9814358274a23a793b06fab511959"
           }
         },
-        "e33c206636b34e859d3c0681e3e0c558": {
+        "06e2351cd4034920af3000edf3bc8ccc": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_f49b9dfff9e34b71b081fd5f17954f5d",
+            "style": "IPY_MODEL_c302e925a9ab4dd295c0b8e50a7a4fca",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 899k/899k [00:00&lt;00:00, 7.50MB/s]",
+            "value": " 899k/899k [00:00&lt;00:00, 6.82MB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_2706662c519949119140b11124f14ebb"
+            "layout": "IPY_MODEL_e3ae3331b22b4edeb7b1677ba9ce2127"
           }
         },
-        "d8fb334f7a2144ccbd5ab04efd441e41": {
+        "51e864e3295d46bb900f6b9405e20a93": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -1614,7 +1614,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "51ac628f4f544c5dbf985accba1134e8": {
+        "b2e9814358274a23a793b06fab511959": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1665,7 +1665,7 @@
             "left": null
           }
         },
-        "f49b9dfff9e34b71b081fd5f17954f5d": {
+        "c302e925a9ab4dd295c0b8e50a7a4fca": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -1679,7 +1679,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "2706662c519949119140b11124f14ebb": {
+        "e3ae3331b22b4edeb7b1677ba9ce2127": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1730,7 +1730,7 @@
             "left": null
           }
         },
-        "641e2f656b0849628c0511b8d0e00236": {
+        "ed6dc547e7a1484dad7ebce5b55114fe": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -1742,15 +1742,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_ad68cbc068e54ac4a3db94ef4ffacaf9",
+            "layout": "IPY_MODEL_f6510fe37e404e0ca54276c767500f87",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_c1317b7e87344bf28299497a4f616b4d",
-              "IPY_MODEL_328d5387c5024554a9e0e3c3e3c00a64"
+              "IPY_MODEL_d797213a5e1f4076b89b07afad1ad5cf",
+              "IPY_MODEL_22f3fe815d964db086cd3d338210417d"
             ]
           }
         },
-        "ad68cbc068e54ac4a3db94ef4ffacaf9": {
+        "f6510fe37e404e0ca54276c767500f87": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1801,12 +1801,12 @@
             "left": null
           }
         },
-        "c1317b7e87344bf28299497a4f616b4d": {
+        "d797213a5e1f4076b89b07afad1ad5cf": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_d4d48e22fcc54caba645e9bb6204d102",
+            "style": "IPY_MODEL_527f1e8c27d34ddf8128df3a19932d7a",
             "_dom_classes": [],
             "description": "Downloading: 100%",
             "_model_name": "FloatProgressModel",
@@ -1821,30 +1821,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_b25a3e07181149798938e93af2ac9c82"
+            "layout": "IPY_MODEL_b27f652dfc864fd9b04a6fd9220e4ea4"
           }
         },
-        "328d5387c5024554a9e0e3c3e3c00a64": {
+        "22f3fe815d964db086cd3d338210417d": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_ab6436322cbf49e18d2e31b64fbee854",
+            "style": "IPY_MODEL_2f8f98ca666d4f3b97b41c73a5c47d5f",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 456k/456k [00:00&lt;00:00, 4.38MB/s]",
+            "value": " 456k/456k [00:00&lt;00:00, 4.30MB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_9e14ab86471243cc97d19ab8c5f878eb"
+            "layout": "IPY_MODEL_b45058eede6749f1b1f9736202bc4d7f"
           }
         },
-        "d4d48e22fcc54caba645e9bb6204d102": {
+        "527f1e8c27d34ddf8128df3a19932d7a": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -1859,7 +1859,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "b25a3e07181149798938e93af2ac9c82": {
+        "b27f652dfc864fd9b04a6fd9220e4ea4": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1910,7 +1910,7 @@
             "left": null
           }
         },
-        "ab6436322cbf49e18d2e31b64fbee854": {
+        "2f8f98ca666d4f3b97b41c73a5c47d5f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -1924,7 +1924,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "9e14ab86471243cc97d19ab8c5f878eb": {
+        "b45058eede6749f1b1f9736202bc4d7f": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -1975,7 +1975,7 @@
             "left": null
           }
         },
-        "8d73e2f87c9a4f459120c52c2c13b99b": {
+        "e59b51b0b2e34e9bbd256bafc1717277": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -1987,15 +1987,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_904dab0f997f4d528ec29b03cfa3f9ce",
+            "layout": "IPY_MODEL_b56202ab2d404b39b00b9aa1cbb65fbe",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_7caf3511f7a8480f9231d0ebc18ad464",
-              "IPY_MODEL_ce3dc2613747408e988663b2d7c0fca7"
+              "IPY_MODEL_13768caca40043bf92e620a26a9e0988",
+              "IPY_MODEL_c134db396eec4653b7f29df79fc37254"
             ]
           }
         },
-        "904dab0f997f4d528ec29b03cfa3f9ce": {
+        "b56202ab2d404b39b00b9aa1cbb65fbe": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2046,12 +2046,12 @@
             "left": null
           }
         },
-        "7caf3511f7a8480f9231d0ebc18ad464": {
+        "13768caca40043bf92e620a26a9e0988": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_818ac8c0164c44dcb75367ba66c403eb",
+            "style": "IPY_MODEL_4a66473ead56437fb5d954bf46ece071",
             "_dom_classes": [],
             "description": "100%",
             "_model_name": "FloatProgressModel",
@@ -2066,30 +2066,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_d744cb6c14e74631a9b682663c3c48eb"
+            "layout": "IPY_MODEL_5d0915c22e2b4125be82c240f974e642"
           }
         },
-        "ce3dc2613747408e988663b2d7c0fca7": {
+        "c134db396eec4653b7f29df79fc37254": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_c668e22e3fa44822b2348c66125e52eb",
+            "style": "IPY_MODEL_20c2b95ec92d40efb0e51148f7bacb18",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 9/9 [00:02&lt;00:00,  3.37ba/s]",
+            "value": " 9/9 [00:02&lt;00:00,  3.38ba/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_5a58d2e05ab547178bde46f38b3f2508"
+            "layout": "IPY_MODEL_b22e9eb4d42d4f1f8bf547f961f6e350"
           }
         },
-        "818ac8c0164c44dcb75367ba66c403eb": {
+        "4a66473ead56437fb5d954bf46ece071": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -2104,7 +2104,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "d744cb6c14e74631a9b682663c3c48eb": {
+        "5d0915c22e2b4125be82c240f974e642": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2155,7 +2155,7 @@
             "left": null
           }
         },
-        "c668e22e3fa44822b2348c66125e52eb": {
+        "20c2b95ec92d40efb0e51148f7bacb18": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -2169,7 +2169,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "5a58d2e05ab547178bde46f38b3f2508": {
+        "b22e9eb4d42d4f1f8bf547f961f6e350": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2220,7 +2220,7 @@
             "left": null
           }
         },
-        "a37a7a7a2f8d4d1da71fa62a09cba0f8": {
+        "4e5ebd96d0c14d4db445c86f7baa92ec": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -2232,15 +2232,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_2a64f468682649338d5c5e39797d4619",
+            "layout": "IPY_MODEL_6efb9c4de70445428bb874e1fb4435b2",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_f1d344a1829d48c0b869c928874017be",
-              "IPY_MODEL_8d239eb5fdeb4c37ad7f8b904eda66d7"
+              "IPY_MODEL_9914ef60e1e143e9bf3801318721253b",
+              "IPY_MODEL_d5fd331d5c0f451bb3600316f15b0b20"
             ]
           }
         },
-        "2a64f468682649338d5c5e39797d4619": {
+        "6efb9c4de70445428bb874e1fb4435b2": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2291,12 +2291,12 @@
             "left": null
           }
         },
-        "f1d344a1829d48c0b869c928874017be": {
+        "9914ef60e1e143e9bf3801318721253b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_fbead18c6de84e6c999c57570edb4660",
+            "style": "IPY_MODEL_b534f36d124f4c04b736c8bb3d17ef4b",
             "_dom_classes": [],
             "description": "100%",
             "_model_name": "FloatProgressModel",
@@ -2311,30 +2311,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_30a0b7c3b3a54806ba701d660b0a1e8c"
+            "layout": "IPY_MODEL_5003ea268d8d403192b3dfa00acc1a6d"
           }
         },
-        "8d239eb5fdeb4c37ad7f8b904eda66d7": {
+        "d5fd331d5c0f451bb3600316f15b0b20": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_796e808439a8450299b51d524f9316f8",
+            "style": "IPY_MODEL_10fa5f75b0b54564a5df5c5c3d23effa",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 2/2 [00:00&lt;00:00,  6.32ba/s]",
+            "value": " 2/2 [00:00&lt;00:00,  6.35ba/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_1a20bf61207d45ddb325719d4b7c9148"
+            "layout": "IPY_MODEL_8692a0b21a244a049514cb249902c62d"
           }
         },
-        "fbead18c6de84e6c999c57570edb4660": {
+        "b534f36d124f4c04b736c8bb3d17ef4b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -2349,7 +2349,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "30a0b7c3b3a54806ba701d660b0a1e8c": {
+        "5003ea268d8d403192b3dfa00acc1a6d": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2400,7 +2400,7 @@
             "left": null
           }
         },
-        "796e808439a8450299b51d524f9316f8": {
+        "10fa5f75b0b54564a5df5c5c3d23effa": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -2414,7 +2414,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "1a20bf61207d45ddb325719d4b7c9148": {
+        "8692a0b21a244a049514cb249902c62d": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2465,7 +2465,7 @@
             "left": null
           }
         },
-        "d7259df55724410398d772e596492785": {
+        "d519baf7018e48dbbc150ca35394e96a": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -2477,15 +2477,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_102db28574914068945ac5a21a881272",
+            "layout": "IPY_MODEL_751b63eb1e7948d999851e21ddcdf5f4",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_3012236fd9a645dc83acc79fc18740a6",
-              "IPY_MODEL_990fdec67b3e476bb857b3a29ee40a18"
+              "IPY_MODEL_58382e71f06e4a288f3a9a63c5adf292",
+              "IPY_MODEL_d2514fa098dd4541ba74d13d1c5bc30f"
             ]
           }
         },
-        "102db28574914068945ac5a21a881272": {
+        "751b63eb1e7948d999851e21ddcdf5f4": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2536,12 +2536,12 @@
             "left": null
           }
         },
-        "3012236fd9a645dc83acc79fc18740a6": {
+        "58382e71f06e4a288f3a9a63c5adf292": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_c2380b3d6ef649b4a746fd7d2987a53f",
+            "style": "IPY_MODEL_4317e25e5ebc4e3e842428a38aa6198a",
             "_dom_classes": [],
             "description": "100%",
             "_model_name": "FloatProgressModel",
@@ -2556,30 +2556,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_74dc804ece004364b02afaa0f2e445e6"
+            "layout": "IPY_MODEL_607dd2aea7e24fb692bc4cf5f55163f5"
           }
         },
-        "990fdec67b3e476bb857b3a29ee40a18": {
+        "d2514fa098dd4541ba74d13d1c5bc30f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_662f444e5b5d406ba6977c3ca2ac3140",
+            "style": "IPY_MODEL_269c5e001b8b47809389a29cb838d5d0",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 2/2 [00:00&lt;00:00,  6.33ba/s]",
+            "value": " 2/2 [00:00&lt;00:00,  6.55ba/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_5fa022229fc3451e8f4ca55d99f5f399"
+            "layout": "IPY_MODEL_134eda2e27744f9ca1097e2fe7663cd0"
           }
         },
-        "c2380b3d6ef649b4a746fd7d2987a53f": {
+        "4317e25e5ebc4e3e842428a38aa6198a": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -2594,7 +2594,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "74dc804ece004364b02afaa0f2e445e6": {
+        "607dd2aea7e24fb692bc4cf5f55163f5": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2645,7 +2645,7 @@
             "left": null
           }
         },
-        "662f444e5b5d406ba6977c3ca2ac3140": {
+        "269c5e001b8b47809389a29cb838d5d0": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -2659,7 +2659,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "5fa022229fc3451e8f4ca55d99f5f399": {
+        "134eda2e27744f9ca1097e2fe7663cd0": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2710,7 +2710,7 @@
             "left": null
           }
         },
-        "9da723c91128430aaf0de657b5d78614": {
+        "af601b804dd342059ff8afc889c7ab57": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -2722,15 +2722,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_fcaa1a0b279f44a383b890e21e7fab98",
+            "layout": "IPY_MODEL_5a0d45791ab84f84a95994f09d43664d",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_c6f0b71cd4044a5eb4a3807b1aabb2a3",
-              "IPY_MODEL_5c77f543bafe4e40a0ef7fdcc46ca840"
+              "IPY_MODEL_d3603c0c982949ca8707435d04538e2a",
+              "IPY_MODEL_3511cb0ebfff41d2b5b0b58fb3876887"
             ]
           }
         },
-        "fcaa1a0b279f44a383b890e21e7fab98": {
+        "5a0d45791ab84f84a95994f09d43664d": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2781,12 +2781,12 @@
             "left": null
           }
         },
-        "c6f0b71cd4044a5eb4a3807b1aabb2a3": {
+        "d3603c0c982949ca8707435d04538e2a": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_5294399a5b17497685ce84d755786427",
+            "style": "IPY_MODEL_95e5d9b12acd4738a4e209dd59bf4be3",
             "_dom_classes": [],
             "description": "Downloading: 100%",
             "_model_name": "FloatProgressModel",
@@ -2801,30 +2801,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_42ae0acfec4644bfb39110c2d220da35"
+            "layout": "IPY_MODEL_80a733d9ed734abf8c88d97e9ef2f681"
           }
         },
-        "5c77f543bafe4e40a0ef7fdcc46ca840": {
+        "3511cb0ebfff41d2b5b0b58fb3876887": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_377bfbd756034a638a79f962e3002b55",
+            "style": "IPY_MODEL_f79076b1dcae4c568bc830c9d9c3a67f",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 481/481 [00:00&lt;00:00, 2.43kB/s]",
+            "value": " 481/481 [00:00&lt;00:00, 2.51kB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_4207ecdfbb8d4be7ab8a37f7025e8ed0"
+            "layout": "IPY_MODEL_36fabbb790bc4f0f9209b50eccff8801"
           }
         },
-        "5294399a5b17497685ce84d755786427": {
+        "95e5d9b12acd4738a4e209dd59bf4be3": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -2839,7 +2839,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "42ae0acfec4644bfb39110c2d220da35": {
+        "80a733d9ed734abf8c88d97e9ef2f681": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2890,7 +2890,7 @@
             "left": null
           }
         },
-        "377bfbd756034a638a79f962e3002b55": {
+        "f79076b1dcae4c568bc830c9d9c3a67f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -2904,7 +2904,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "4207ecdfbb8d4be7ab8a37f7025e8ed0": {
+        "36fabbb790bc4f0f9209b50eccff8801": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -2955,7 +2955,7 @@
             "left": null
           }
         },
-        "64f27e101aeb4b66aae1f280401adcc8": {
+        "f730003e4d3b497b9f7c6a88ea44781a": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "state": {
@@ -2967,15 +2967,15 @@
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "box_style": "",
-            "layout": "IPY_MODEL_243fc2fe7d9d492cb95e7e84da403a27",
+            "layout": "IPY_MODEL_0080c6c1e3ea455f9daec3f1e5e24dd3",
             "_model_module": "@jupyter-widgets/controls",
             "children": [
-              "IPY_MODEL_14e8e514752c43c5be0613a90342ec28",
-              "IPY_MODEL_b60924467c084300bc84b3e2454a92e4"
+              "IPY_MODEL_afe246745db548bb8448bc17d09724f9",
+              "IPY_MODEL_63cbfbb3bf054d6683c5006c9a89c8e2"
             ]
           }
         },
-        "243fc2fe7d9d492cb95e7e84da403a27": {
+        "0080c6c1e3ea455f9daec3f1e5e24dd3": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -3026,12 +3026,12 @@
             "left": null
           }
         },
-        "14e8e514752c43c5be0613a90342ec28": {
+        "afe246745db548bb8448bc17d09724f9": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "state": {
             "_view_name": "ProgressView",
-            "style": "IPY_MODEL_2963c36cb8d747a2890dc5d1b287d345",
+            "style": "IPY_MODEL_cc20ac31f36a4d5d857d8f04b3914d60",
             "_dom_classes": [],
             "description": "Downloading: 100%",
             "_model_name": "FloatProgressModel",
@@ -3046,30 +3046,30 @@
             "min": 0,
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_bf307055977f473e99b94a90c95f8269"
+            "layout": "IPY_MODEL_1ca41b6687bc4cfa9f2854ff674a8280"
           }
         },
-        "b60924467c084300bc84b3e2454a92e4": {
+        "63cbfbb3bf054d6683c5006c9a89c8e2": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "state": {
             "_view_name": "HTMLView",
-            "style": "IPY_MODEL_41a7a6711efb495fbdca9b40ec2d0a59",
+            "style": "IPY_MODEL_670cfafa85ea4b878f03bcd5aad4bc0c",
             "_dom_classes": [],
             "description": "",
             "_model_name": "HTMLModel",
             "placeholder": "​",
             "_view_module": "@jupyter-widgets/controls",
             "_model_module_version": "1.5.0",
-            "value": " 501M/501M [00:26&lt;00:00, 19.1MB/s]",
+            "value": " 501M/501M [00:25&lt;00:00, 19.8MB/s]",
             "_view_count": null,
             "_view_module_version": "1.5.0",
             "description_tooltip": null,
             "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_29819fe095904d3e8d15522c7a9ef416"
+            "layout": "IPY_MODEL_aecbf9a9f921435a86593d2dcca5550a"
           }
         },
-        "2963c36cb8d747a2890dc5d1b287d345": {
+        "cc20ac31f36a4d5d857d8f04b3914d60": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "state": {
@@ -3084,7 +3084,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "bf307055977f473e99b94a90c95f8269": {
+        "1ca41b6687bc4cfa9f2854ff674a8280": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -3135,7 +3135,7 @@
             "left": null
           }
         },
-        "41a7a6711efb495fbdca9b40ec2d0a59": {
+        "670cfafa85ea4b878f03bcd5aad4bc0c": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "state": {
@@ -3149,7 +3149,7 @@
             "_model_module": "@jupyter-widgets/controls"
           }
         },
-        "29819fe095904d3e8d15522c7a9ef416": {
+        "aecbf9a9f921435a86593d2dcca5550a": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "state": {
@@ -3236,66 +3236,84 @@
       "cell_type": "code",
       "metadata": {
         "id": "ju-alwbHmKYA",
-        "outputId": "36e747e5-7c9a-456f-cb80-234e75dd75ec",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "outputId": "ae564fa9-46ac-4db9-eb16-4e5903a727cd"
       },
       "source": [
         "!pip install adapter-transformers\n",
         "!pip install datasets"
       ],
-      "execution_count": 3,
+      "execution_count": 1,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
             "Collecting adapter-transformers\n",
             "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/9d/44/1370c187aba1349d56d6813ec4de54644d15e154983050f4923ce5455069/adapter_transformers-1.1.0-py3-none-any.whl (1.3MB)\n",
-            "\r\u001b[K     |▎                               | 10kB 21.1MB/s eta 0:00:01\r\u001b[K     |▌                               | 20kB 25.3MB/s eta 0:00:01\r\u001b[K     |▊                               | 30kB 19.1MB/s eta 0:00:01\r\u001b[K     |█                               | 40kB 17.3MB/s eta 0:00:01\r\u001b[K     |█▎                              | 51kB 13.5MB/s eta 0:00:01\r\u001b[K     |█▌                              | 61kB 13.5MB/s eta 0:00:01\r\u001b[K     |█▊                              | 71kB 13.1MB/s eta 0:00:01\r\u001b[K     |██                              | 81kB 13.5MB/s eta 0:00:01\r\u001b[K     |██▏                             | 92kB 13.6MB/s eta 0:00:01\r\u001b[K     |██▌                             | 102kB 14.7MB/s eta 0:00:01\r\u001b[K     |██▊                             | 112kB 14.7MB/s eta 0:00:01\r\u001b[K     |███                             | 122kB 14.7MB/s eta 0:00:01\r\u001b[K     |███▏                            | 133kB 14.7MB/s eta 0:00:01\r\u001b[K     |███▍                            | 143kB 14.7MB/s eta 0:00:01\r\u001b[K     |███▊                            | 153kB 14.7MB/s eta 0:00:01\r\u001b[K     |████                            | 163kB 14.7MB/s eta 0:00:01\r\u001b[K     |████▏                           | 174kB 14.7MB/s eta 0:00:01\r\u001b[K     |████▍                           | 184kB 14.7MB/s eta 0:00:01\r\u001b[K     |████▊                           | 194kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████                           | 204kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████▏                          | 215kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████▍                          | 225kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████▋                          | 235kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████                          | 245kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████▏                         | 256kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████▍                         | 266kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████▋                         | 276kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████▉                         | 286kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████▏                        | 296kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████▍                        | 307kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████▋                        | 317kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████▉                        | 327kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████▏                       | 337kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████▍                       | 348kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████▋                       | 358kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████▉                       | 368kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████                       | 378kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████▍                      | 389kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████▋                      | 399kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████▉                      | 409kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████                      | 419kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████▎                     | 430kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████▋                     | 440kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████▉                     | 450kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████                     | 460kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████▎                    | 471kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████▌                    | 481kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████▉                    | 491kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████                    | 501kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████▎                   | 512kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████▌                   | 522kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████▉                   | 532kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████                   | 542kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████▎                  | 552kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████▌                  | 563kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████▊                  | 573kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████                  | 583kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████▎                 | 593kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████▌                 | 604kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████▊                 | 614kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████                 | 624kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████▎                | 634kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████▌                | 645kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████▊                | 655kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████                | 665kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████▎               | 675kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████▌               | 686kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████▊               | 696kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████               | 706kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████▏              | 716kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████▌              | 727kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████▊              | 737kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████              | 747kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████▏             | 757kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████▍             | 768kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████▊             | 778kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████             | 788kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████▏            | 798kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████▍            | 808kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████▊            | 819kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████            | 829kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████▏           | 839kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████▍           | 849kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████▋           | 860kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████           | 870kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████▏          | 880kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████▍          | 890kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████▋          | 901kB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████▉          | 911kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████▏         | 921kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████▍         | 931kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████▋         | 942kB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████▉         | 952kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████         | 962kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████▍        | 972kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████▋        | 983kB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████▉        | 993kB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████        | 1.0MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████▍       | 1.0MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████▋       | 1.0MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████▉       | 1.0MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████       | 1.0MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▎      | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▋      | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▉      | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████      | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▎     | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▌     | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▉     | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████     | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████▎    | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████▌    | 1.1MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████▉    | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████    | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▎   | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▌   | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▊   | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████   | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████▎  | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████▌  | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████▊  | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████  | 1.2MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▎ | 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▌ | 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▊ | 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████ | 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████▎| 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████▌| 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████▊| 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 1.3MB 14.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 1.3MB 14.7MB/s \n",
-            "\u001b[?25hRequirement already satisfied: protobuf in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (3.12.4)\n",
-            "Requirement already satisfied: sentencepiece==0.1.91 in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (0.1.91)\n",
-            "Requirement already satisfied: tokenizers==0.9.3 in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (0.9.3)\n",
-            "Requirement already satisfied: sacremoses in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (0.0.43)\n",
-            "Requirement already satisfied: requests in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (2.23.0)\n",
-            "Requirement already satisfied: dataclasses; python_version < \"3.7\" in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (0.8)\n",
+            "\u001b[K     |████████████████████████████████| 1.3MB 15.3MB/s \n",
+            "\u001b[?25hRequirement already satisfied: regex!=2019.12.17 in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (2019.12.20)\n",
+            "Collecting sentencepiece==0.1.91\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/d4/a4/d0a884c4300004a78cca907a6ff9a5e9fe4f090f5d95ab341c53d28cbc58/sentencepiece-0.1.91-cp36-cp36m-manylinux1_x86_64.whl (1.1MB)\n",
+            "\u001b[K     |████████████████████████████████| 1.1MB 54.7MB/s \n",
+            "\u001b[?25hRequirement already satisfied: dataclasses; python_version < \"3.7\" in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (0.8)\n",
             "Requirement already satisfied: numpy in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (1.18.5)\n",
-            "Requirement already satisfied: regex!=2019.12.17 in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (2019.12.20)\n",
-            "Requirement already satisfied: tqdm>=4.27 in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (4.41.1)\n",
+            "Collecting sacremoses\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/7d/34/09d19aff26edcc8eb2a01bed8e98f13a1537005d31e95233fd48216eed10/sacremoses-0.0.43.tar.gz (883kB)\n",
+            "\u001b[K     |████████████████████████████████| 890kB 54.1MB/s \n",
+            "\u001b[?25hRequirement already satisfied: requests in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (2.23.0)\n",
             "Requirement already satisfied: packaging in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (20.7)\n",
+            "Requirement already satisfied: tqdm>=4.27 in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (4.41.1)\n",
             "Requirement already satisfied: filelock in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (3.0.12)\n",
-            "Requirement already satisfied: six>=1.9 in /usr/local/lib/python3.6/dist-packages (from protobuf->adapter-transformers) (1.15.0)\n",
-            "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from protobuf->adapter-transformers) (50.3.2)\n",
+            "Collecting tokenizers==0.9.3\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/4c/34/b39eb9994bc3c999270b69c9eea40ecc6f0e97991dba28282b9fd32d44ee/tokenizers-0.9.3-cp36-cp36m-manylinux1_x86_64.whl (2.9MB)\n",
+            "\u001b[K     |████████████████████████████████| 2.9MB 49.5MB/s \n",
+            "\u001b[?25hRequirement already satisfied: protobuf in /usr/local/lib/python3.6/dist-packages (from adapter-transformers) (3.12.4)\n",
+            "Requirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from sacremoses->adapter-transformers) (1.15.0)\n",
             "Requirement already satisfied: click in /usr/local/lib/python3.6/dist-packages (from sacremoses->adapter-transformers) (7.1.2)\n",
             "Requirement already satisfied: joblib in /usr/local/lib/python3.6/dist-packages (from sacremoses->adapter-transformers) (0.17.0)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests->adapter-transformers) (2020.12.5)\n",
             "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/dist-packages (from requests->adapter-transformers) (2.10)\n",
             "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.6/dist-packages (from requests->adapter-transformers) (1.24.3)\n",
             "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests->adapter-transformers) (3.0.4)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests->adapter-transformers) (2020.12.5)\n",
             "Requirement already satisfied: pyparsing>=2.0.2 in /usr/local/lib/python3.6/dist-packages (from packaging->adapter-transformers) (2.4.7)\n",
-            "Installing collected packages: adapter-transformers\n",
-            "Successfully installed adapter-transformers-1.1.0\n",
+            "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from protobuf->adapter-transformers) (50.3.2)\n",
+            "Building wheels for collected packages: sacremoses\n",
+            "  Building wheel for sacremoses (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for sacremoses: filename=sacremoses-0.0.43-cp36-none-any.whl size=893261 sha256=86e2813b532d2dfb08a700851485b4328005e280bb603e0b40b8722d257151a5\n",
+            "  Stored in directory: /root/.cache/pip/wheels/29/3c/fd/7ce5c3f0666dab31a50123635e6fb5e19ceb42ce38d4e58f45\n",
+            "Successfully built sacremoses\n",
+            "Installing collected packages: sentencepiece, sacremoses, tokenizers, adapter-transformers\n",
+            "Successfully installed adapter-transformers-1.1.0 sacremoses-0.0.43 sentencepiece-0.1.91 tokenizers-0.9.3\n",
             "Collecting datasets\n",
-            "  Using cached https://files.pythonhosted.org/packages/1a/38/0c24dce24767386123d528d27109024220db0e7a04467b658d587695241a/datasets-1.1.3-py3-none-any.whl\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/1a/38/0c24dce24767386123d528d27109024220db0e7a04467b658d587695241a/datasets-1.1.3-py3-none-any.whl (153kB)\n",
+            "\u001b[K     |████████████████████████████████| 163kB 13.1MB/s \n",
+            "\u001b[?25hCollecting xxhash\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f7/73/826b19f3594756cb1c6c23d2fbd8ca6a77a9cd3b650c9dec5acc85004c38/xxhash-2.0.0-cp36-cp36m-manylinux2010_x86_64.whl (242kB)\n",
+            "\u001b[K     |████████████████████████████████| 245kB 32.5MB/s \n",
+            "\u001b[?25hRequirement already satisfied: pandas in /usr/local/lib/python3.6/dist-packages (from datasets) (1.1.5)\n",
             "Requirement already satisfied: numpy>=1.17 in /usr/local/lib/python3.6/dist-packages (from datasets) (1.18.5)\n",
-            "Requirement already satisfied: tqdm<4.50.0,>=4.27 in /usr/local/lib/python3.6/dist-packages (from datasets) (4.41.1)\n",
-            "Collecting pyarrow>=0.17.1\n",
-            "  Using cached https://files.pythonhosted.org/packages/d7/e1/27958a70848f8f7089bff8d6ebe42519daf01f976d28b481e1bfd52c8097/pyarrow-2.0.0-cp36-cp36m-manylinux2014_x86_64.whl\n",
-            "Requirement already satisfied: requests>=2.19.0 in /usr/local/lib/python3.6/dist-packages (from datasets) (2.23.0)\n",
-            "Requirement already satisfied: pandas in /usr/local/lib/python3.6/dist-packages (from datasets) (1.1.5)\n",
-            "Requirement already satisfied: xxhash in /usr/local/lib/python3.6/dist-packages (from datasets) (2.0.0)\n",
-            "Requirement already satisfied: dill in /usr/local/lib/python3.6/dist-packages (from datasets) (0.3.3)\n",
-            "Requirement already satisfied: dataclasses; python_version < \"3.7\" in /usr/local/lib/python3.6/dist-packages (from datasets) (0.8)\n",
             "Requirement already satisfied: multiprocess in /usr/local/lib/python3.6/dist-packages (from datasets) (0.70.11.1)\n",
-            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (1.24.3)\n",
-            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (2.10)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (2020.12.5)\n",
-            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (3.0.4)\n",
+            "Requirement already satisfied: tqdm<4.50.0,>=4.27 in /usr/local/lib/python3.6/dist-packages (from datasets) (4.41.1)\n",
+            "Requirement already satisfied: dill in /usr/local/lib/python3.6/dist-packages (from datasets) (0.3.3)\n",
+            "Requirement already satisfied: requests>=2.19.0 in /usr/local/lib/python3.6/dist-packages (from datasets) (2.23.0)\n",
+            "Collecting pyarrow>=0.17.1\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/d7/e1/27958a70848f8f7089bff8d6ebe42519daf01f976d28b481e1bfd52c8097/pyarrow-2.0.0-cp36-cp36m-manylinux2014_x86_64.whl (17.7MB)\n",
+            "\u001b[K     |████████████████████████████████| 17.7MB 200kB/s \n",
+            "\u001b[?25hRequirement already satisfied: dataclasses; python_version < \"3.7\" in /usr/local/lib/python3.6/dist-packages (from datasets) (0.8)\n",
             "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.6/dist-packages (from pandas->datasets) (2018.9)\n",
             "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.6/dist-packages (from pandas->datasets) (2.8.1)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (2020.12.5)\n",
+            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (1.24.3)\n",
+            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (2.10)\n",
+            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests>=2.19.0->datasets) (3.0.4)\n",
             "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.6/dist-packages (from python-dateutil>=2.7.3->pandas->datasets) (1.15.0)\n",
-            "Installing collected packages: pyarrow, datasets\n",
-            "Successfully installed datasets-1.1.3 pyarrow-2.0.0\n"
+            "Installing collected packages: xxhash, pyarrow, datasets\n",
+            "  Found existing installation: pyarrow 0.14.1\n",
+            "    Uninstalling pyarrow-0.14.1:\n",
+            "      Successfully uninstalled pyarrow-0.14.1\n",
+            "Successfully installed datasets-1.1.3 pyarrow-2.0.0 xxhash-2.0.0\n"
           ],
           "name": "stdout"
         }
@@ -3320,57 +3338,57 @@
           "base_uri": "https://localhost:8080/",
           "height": 262,
           "referenced_widgets": [
-            "c3aa99f89b76454c96a862454a359f6b",
-            "7487c6cc822d491597a3aada5af8e454",
-            "c434f4813daf4dd699c553d2a6736e00",
-            "f9f50a85c48b4d4786ac16836ef0e083",
-            "cb1ee710a1344fe8b0c817249fb51e3d",
-            "adb199dacb9c4881be7ae6ffdd665b54",
-            "643c34677a93499fa233e5f52649b0e0",
-            "94832fd6f4f7419bac117598f804d1c6",
-            "601e07e7e60e440aab0792c52c4e59eb",
-            "c472912011a6462088eeeb2baba50bf0",
-            "075ff4547bcd44e48ec9255ade034dcf",
-            "f70900ce8da44d7b98ad436057e61a14",
-            "7adefdefdb0d4e3c89dea3f94355a22a",
-            "c23742b6f64a4896a929a663df319a07",
-            "366d05764cdf4615840ca2a4882c714b",
-            "d80a43cd09e74f6488953d0375f16630",
-            "278d86f375a2411c95ffa67ab3ead553",
-            "17c5f9d76aa143dd97b28bd022b65928",
-            "3a23fd2815db4a9e932d4b24730544cf",
-            "d1fcae5dc5ae4c4ba3a88acfc2ab5c6b",
-            "a9e1826f0d3b4097b55d94f6059b9c19",
-            "3f1434df2ae44c6a813fdbcd536ceba1",
-            "7c83f0a51d62405998a1daf840cf8fbc",
-            "3c5482f9f86945b6a1ca565b996e6afe",
-            "a1c534924ac14e94b86c0896ef011bda",
-            "99bc3614faf543c99c77981c5a244e87",
-            "1b99a4ada8ec41bbab8bf652ef90f199",
-            "5b623b4e7c7d44098d0e731a1f1a650f",
-            "16c50d9feaa44f8b8c8b05aff6f8d773",
-            "295c22961e5846f3a674c306ccf77919",
-            "a2d8e18039a142e98ec0192bb419b311",
-            "3ae163fe2441420cadda46c45c8b0788",
-            "abf1d33e12ab44a183abdfc920377d1f",
-            "65831e7d830a4aa6959343b3203646b9",
-            "71f96c798571403f8d24def284d976dd",
-            "52ccd2b56733499ab1704b3086ebf5f3",
-            "64fd5c025a0a493abe4d0e020fe7777b",
-            "ba0d9249f4c249dfb18f5a6b45b50b6a",
-            "719018907f3944cab4a3678c10e6a317",
-            "b3c4f8134a364dd6bd37d41943b8496f",
-            "0ad0872dac514827b2cf26bec2338efb",
-            "cba481c9f6b2416da3424f347c72cdc6",
-            "0b92b5b3b0384913a6aa3cd592a0bc54",
-            "5bd85517e14a4df0bc7051479e6de15c",
-            "3abd3365cd104e419626427b5de97278",
-            "87969f6fc6ee41208e8cecf1ff646b67",
-            "0f96976f61bf4ff29edac10115d1eedd",
-            "de5793113feb44e2996edf83325dbe6a"
+            "3a9b4ec9a3e748c7a21fe3cda7fedd8c",
+            "d32b921e161e49feaa09de4b371753f2",
+            "8d07b853c60545bcaab48d3e45366138",
+            "97a23288915a4a17bbecf24995907e9f",
+            "9f248795ccfb48ef8a29b4d1b52f8b8a",
+            "cb6d5faa575a4a2fb33cdf714533e223",
+            "de7ddc9b059e437f8e2d4bce3b6a032a",
+            "c0226a0682884615a15370865a9414b8",
+            "89d542a0e85f4fbfaff2ffa617052bc6",
+            "447df269f40f45b19e6c46addb25fb3c",
+            "1f6c85f8ae67454eaf5970a544087d07",
+            "e394434dce9d4b42a5a2e98a8d93e69d",
+            "b0f931a617d44c359db0ec746ee7028f",
+            "2c607118fe6143fca05ca60329050800",
+            "79dfc3aa220c4894b94e02c784d47d6b",
+            "a8629ce41ef641cdb69fbbfc8a599a99",
+            "0c1047a82d20482a98ae293269e5af98",
+            "1798b1a3e6f1471fa594b5286d139d8c",
+            "998d43a540124e65921b3370571fb286",
+            "bc3376f518454e3c96d532845c51cf86",
+            "609717db231447c9b151ae0761678d28",
+            "9d5910aea7c8439e8b545a73d5bca27a",
+            "2f967ca5a75e4071a50a9c8152f23491",
+            "b8bc66a38aab4722ac9d0931c9904bf7",
+            "cd254feed6184bc7aa08b4a17062dd03",
+            "2073764124464e97964d23233335539e",
+            "25f3fee587334dab9e3e11be00e5b584",
+            "0b390c2b77a9488289f7f5fe7d11fd16",
+            "cd667d66c2184a5a8747b903d0ee426e",
+            "3c5da4b734a04d658da3610e7b07aba8",
+            "6ad6848c3a62406eb63fa2aafba0ae9a",
+            "0ef74a3d0b7a414a8d8ac3855624a6e8",
+            "0049be330f83480bb2374d9433f380f2",
+            "19de841f95574870afabe05997fa0c0e",
+            "1b24a2cae2774e32ac78026d659143cd",
+            "06e17d538f2945d0b42c09ebad28ad58",
+            "c51a4a10d27e45e5a17a04fd2108eee5",
+            "7f391d99245645c7815bdd0ca552e029",
+            "fa3e63d18e2645559e74d63013362bb6",
+            "19b54ac29440422caa8272418589d181",
+            "e0613dc56e884e93a5a200c7c48f1ee1",
+            "ec28ae3ce7334732b39a70b5872285cb",
+            "3cc2b4ff25e24271913f689f7c096d1b",
+            "3a8fd5305d6447c1b49c29429ebd6e89",
+            "fdc0603de2a64c5abf7ffdd0bb1a2bf2",
+            "d4bdf3213e8f43c8b00f7e3c993aa4a3",
+            "5caf1a4fbd4d49eda2f786ce4f485bbb",
+            "9a4deb0013714533a41c340461fa40a8"
           ]
         },
-        "outputId": "14221c65-2503-4959-80e8-608a8ffa504f"
+        "outputId": "634cae26-65e1-4d48-97dd-184349a2a67e"
       },
       "source": [
         "from datasets import load_dataset\n",
@@ -3378,13 +3396,13 @@
         "dataset = load_dataset(\"rotten_tomatoes\")\n",
         "dataset.num_rows"
       ],
-      "execution_count": 4,
+      "execution_count": 2,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "c3aa99f89b76454c96a862454a359f6b",
+              "model_id": "3a9b4ec9a3e748c7a21fe3cda7fedd8c",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3407,7 +3425,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "601e07e7e60e440aab0792c52c4e59eb",
+              "model_id": "89d542a0e85f4fbfaff2ffa617052bc6",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3422,6 +3440,13 @@
         {
           "output_type": "stream",
           "text": [
+            "\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "stream",
+          "text": [
             "Using custom data configuration default\n"
           ],
           "name": "stderr"
@@ -3429,7 +3454,6 @@
         {
           "output_type": "stream",
           "text": [
-            "\n",
             "Downloading and preparing dataset rotten_tomatoes_movie_review/default (download: 476.34 KiB, generated: 1.28 MiB, post-processed: Unknown size, total: 1.75 MiB) to /root/.cache/huggingface/datasets/rotten_tomatoes_movie_review/default/1.0.0/9198dbc50858df8bdb0d5f18ccaf33125800af96ad8434bc8b829918c987ee8a...\n"
           ],
           "name": "stdout"
@@ -3438,7 +3462,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "278d86f375a2411c95ffa67ab3ead553",
+              "model_id": "0c1047a82d20482a98ae293269e5af98",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3461,7 +3485,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "a1c534924ac14e94b86c0896ef011bda",
+              "model_id": "cd254feed6184bc7aa08b4a17062dd03",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3484,7 +3508,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "abf1d33e12ab44a183abdfc920377d1f",
+              "model_id": "0049be330f83480bb2374d9433f380f2",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3507,7 +3531,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "0ad0872dac514827b2cf26bec2338efb",
+              "model_id": "e0613dc56e884e93a5a200c7c48f1ee1",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3536,7 +3560,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 4
+          "execution_count": 2
         }
       ]
     },
@@ -3556,12 +3580,12 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "96bad6a4-0fe5-4f0a-a48f-0e79e06e6430"
+        "outputId": "1b156952-c010-4fad-df69-8c9be0427e30"
       },
       "source": [
         "dataset['train'][0]"
       ],
-      "execution_count": 5,
+      "execution_count": 3,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -3574,7 +3598,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 5
+          "execution_count": 3
         }
       ]
     },
@@ -3595,49 +3619,49 @@
           "base_uri": "https://localhost:8080/",
           "height": 269,
           "referenced_widgets": [
-            "4a8329b6f8ff4802bd9d6c437b84e329",
-            "770c47502de04f059dc53b1cca002c9b",
-            "9f8d42ec09d84646a786a2547906846f",
-            "e33c206636b34e859d3c0681e3e0c558",
-            "d8fb334f7a2144ccbd5ab04efd441e41",
-            "51ac628f4f544c5dbf985accba1134e8",
-            "f49b9dfff9e34b71b081fd5f17954f5d",
-            "2706662c519949119140b11124f14ebb",
-            "641e2f656b0849628c0511b8d0e00236",
-            "ad68cbc068e54ac4a3db94ef4ffacaf9",
-            "c1317b7e87344bf28299497a4f616b4d",
-            "328d5387c5024554a9e0e3c3e3c00a64",
-            "d4d48e22fcc54caba645e9bb6204d102",
-            "b25a3e07181149798938e93af2ac9c82",
-            "ab6436322cbf49e18d2e31b64fbee854",
-            "9e14ab86471243cc97d19ab8c5f878eb",
-            "8d73e2f87c9a4f459120c52c2c13b99b",
-            "904dab0f997f4d528ec29b03cfa3f9ce",
-            "7caf3511f7a8480f9231d0ebc18ad464",
-            "ce3dc2613747408e988663b2d7c0fca7",
-            "818ac8c0164c44dcb75367ba66c403eb",
-            "d744cb6c14e74631a9b682663c3c48eb",
-            "c668e22e3fa44822b2348c66125e52eb",
-            "5a58d2e05ab547178bde46f38b3f2508",
-            "a37a7a7a2f8d4d1da71fa62a09cba0f8",
-            "2a64f468682649338d5c5e39797d4619",
-            "f1d344a1829d48c0b869c928874017be",
-            "8d239eb5fdeb4c37ad7f8b904eda66d7",
-            "fbead18c6de84e6c999c57570edb4660",
-            "30a0b7c3b3a54806ba701d660b0a1e8c",
-            "796e808439a8450299b51d524f9316f8",
-            "1a20bf61207d45ddb325719d4b7c9148",
-            "d7259df55724410398d772e596492785",
-            "102db28574914068945ac5a21a881272",
-            "3012236fd9a645dc83acc79fc18740a6",
-            "990fdec67b3e476bb857b3a29ee40a18",
-            "c2380b3d6ef649b4a746fd7d2987a53f",
-            "74dc804ece004364b02afaa0f2e445e6",
-            "662f444e5b5d406ba6977c3ca2ac3140",
-            "5fa022229fc3451e8f4ca55d99f5f399"
+            "eaa479faec154441b91b4540af762ef1",
+            "924af57eb418449a8a2aa5e64ddd3169",
+            "2295fe241e3945aaa61886ad9174dd99",
+            "06e2351cd4034920af3000edf3bc8ccc",
+            "51e864e3295d46bb900f6b9405e20a93",
+            "b2e9814358274a23a793b06fab511959",
+            "c302e925a9ab4dd295c0b8e50a7a4fca",
+            "e3ae3331b22b4edeb7b1677ba9ce2127",
+            "ed6dc547e7a1484dad7ebce5b55114fe",
+            "f6510fe37e404e0ca54276c767500f87",
+            "d797213a5e1f4076b89b07afad1ad5cf",
+            "22f3fe815d964db086cd3d338210417d",
+            "527f1e8c27d34ddf8128df3a19932d7a",
+            "b27f652dfc864fd9b04a6fd9220e4ea4",
+            "2f8f98ca666d4f3b97b41c73a5c47d5f",
+            "b45058eede6749f1b1f9736202bc4d7f",
+            "e59b51b0b2e34e9bbd256bafc1717277",
+            "b56202ab2d404b39b00b9aa1cbb65fbe",
+            "13768caca40043bf92e620a26a9e0988",
+            "c134db396eec4653b7f29df79fc37254",
+            "4a66473ead56437fb5d954bf46ece071",
+            "5d0915c22e2b4125be82c240f974e642",
+            "20c2b95ec92d40efb0e51148f7bacb18",
+            "b22e9eb4d42d4f1f8bf547f961f6e350",
+            "4e5ebd96d0c14d4db445c86f7baa92ec",
+            "6efb9c4de70445428bb874e1fb4435b2",
+            "9914ef60e1e143e9bf3801318721253b",
+            "d5fd331d5c0f451bb3600316f15b0b20",
+            "b534f36d124f4c04b736c8bb3d17ef4b",
+            "5003ea268d8d403192b3dfa00acc1a6d",
+            "10fa5f75b0b54564a5df5c5c3d23effa",
+            "8692a0b21a244a049514cb249902c62d",
+            "d519baf7018e48dbbc150ca35394e96a",
+            "751b63eb1e7948d999851e21ddcdf5f4",
+            "58382e71f06e4a288f3a9a63c5adf292",
+            "d2514fa098dd4541ba74d13d1c5bc30f",
+            "4317e25e5ebc4e3e842428a38aa6198a",
+            "607dd2aea7e24fb692bc4cf5f55163f5",
+            "269c5e001b8b47809389a29cb838d5d0",
+            "134eda2e27744f9ca1097e2fe7663cd0"
           ]
         },
-        "outputId": "82f215ff-06f9-405a-99cb-6081053c881b"
+        "outputId": "15947576-7241-4598-a40a-7fdbe04566f5"
       },
       "source": [
         "from transformers import RobertaTokenizer\n",
@@ -3655,13 +3679,13 @@
         "# Transform to pytorch tensors and only output the required columns\n",
         "dataset.set_format(type=\"torch\", columns=[\"input_ids\", \"attention_mask\", \"labels\"])"
       ],
-      "execution_count": 6,
+      "execution_count": 4,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "4a8329b6f8ff4802bd9d6c437b84e329",
+              "model_id": "eaa479faec154441b91b4540af762ef1",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3684,7 +3708,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "641e2f656b0849628c0511b8d0e00236",
+              "model_id": "ed6dc547e7a1484dad7ebce5b55114fe",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3707,7 +3731,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "8d73e2f87c9a4f459120c52c2c13b99b",
+              "model_id": "e59b51b0b2e34e9bbd256bafc1717277",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3730,7 +3754,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "a37a7a7a2f8d4d1da71fa62a09cba0f8",
+              "model_id": "4e5ebd96d0c14d4db445c86f7baa92ec",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3753,7 +3777,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "d7259df55724410398d772e596492785",
+              "model_id": "d519baf7018e48dbbc150ca35394e96a",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3802,25 +3826,25 @@
           "base_uri": "https://localhost:8080/",
           "height": 230,
           "referenced_widgets": [
-            "9da723c91128430aaf0de657b5d78614",
-            "fcaa1a0b279f44a383b890e21e7fab98",
-            "c6f0b71cd4044a5eb4a3807b1aabb2a3",
-            "5c77f543bafe4e40a0ef7fdcc46ca840",
-            "5294399a5b17497685ce84d755786427",
-            "42ae0acfec4644bfb39110c2d220da35",
-            "377bfbd756034a638a79f962e3002b55",
-            "4207ecdfbb8d4be7ab8a37f7025e8ed0",
-            "64f27e101aeb4b66aae1f280401adcc8",
-            "243fc2fe7d9d492cb95e7e84da403a27",
-            "14e8e514752c43c5be0613a90342ec28",
-            "b60924467c084300bc84b3e2454a92e4",
-            "2963c36cb8d747a2890dc5d1b287d345",
-            "bf307055977f473e99b94a90c95f8269",
-            "41a7a6711efb495fbdca9b40ec2d0a59",
-            "29819fe095904d3e8d15522c7a9ef416"
+            "af601b804dd342059ff8afc889c7ab57",
+            "5a0d45791ab84f84a95994f09d43664d",
+            "d3603c0c982949ca8707435d04538e2a",
+            "3511cb0ebfff41d2b5b0b58fb3876887",
+            "95e5d9b12acd4738a4e209dd59bf4be3",
+            "80a733d9ed734abf8c88d97e9ef2f681",
+            "f79076b1dcae4c568bc830c9d9c3a67f",
+            "36fabbb790bc4f0f9209b50eccff8801",
+            "f730003e4d3b497b9f7c6a88ea44781a",
+            "0080c6c1e3ea455f9daec3f1e5e24dd3",
+            "afe246745db548bb8448bc17d09724f9",
+            "63cbfbb3bf054d6683c5006c9a89c8e2",
+            "cc20ac31f36a4d5d857d8f04b3914d60",
+            "1ca41b6687bc4cfa9f2854ff674a8280",
+            "670cfafa85ea4b878f03bcd5aad4bc0c",
+            "aecbf9a9f921435a86593d2dcca5550a"
           ]
         },
-        "outputId": "747d347b-d7e6-443d-ebab-b887b493db23"
+        "outputId": "3f748f21-fcfe-4631-9751-3b1d27684296"
       },
       "source": [
         "from transformers import RobertaConfig, RobertaModelWithHeads\n",
@@ -3828,20 +3852,19 @@
         "config = RobertaConfig.from_pretrained(\n",
         "    \"roberta-base\",\n",
         "    num_labels=2,\n",
-        "    id2label={ 0: \"👎\", 1: \"👍\"},\n",
         ")\n",
         "model = RobertaModelWithHeads.from_pretrained(\n",
         "    \"roberta-base\",\n",
         "    config=config,\n",
         ")"
       ],
-      "execution_count": 7,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "9da723c91128430aaf0de657b5d78614",
+              "model_id": "af601b804dd342059ff8afc889c7ab57",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3864,7 +3887,7 @@
           "output_type": "display_data",
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "64f27e101aeb4b66aae1f280401adcc8",
+              "model_id": "f730003e4d3b497b9f7c6a88ea44781a",
               "version_minor": 0,
               "version_major": 2
             },
@@ -3921,11 +3944,15 @@
         "# Add a new adapter\n",
         "model.add_adapter(\"rotten_tomatoes\", AdapterType.text_task)\n",
         "# Add a matching classification head\n",
-        "model.add_classification_head(\"rotten_tomatoes\", num_labels=2)\n",
+        "model.add_classification_head(\n",
+        "    \"rotten_tomatoes\",\n",
+        "    num_labels=2,\n",
+        "    id2label={ 0: \"👎\", 1: \"👍\"}\n",
+        "  )\n",
         "# Activate the adapter\n",
         "model.train_adapter(\"rotten_tomatoes\")"
       ],
-      "execution_count": 8,
+      "execution_count": 6,
       "outputs": []
     },
     {
@@ -3972,7 +3999,7 @@
         "    compute_metrics=compute_accuracy,\n",
         ")"
       ],
-      "execution_count": 9,
+      "execution_count": 7,
       "outputs": []
     },
     {
@@ -3992,12 +4019,12 @@
           "base_uri": "https://localhost:8080/",
           "height": 401
         },
-        "outputId": "c85848ef-a396-42ea-fa5e-0df97f593902"
+        "outputId": "7fb154f4-1e4c-4e8c-8118-b5a709d57429"
       },
       "source": [
         "trainer.train()"
       ],
-      "execution_count": 10,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "stream",
@@ -4024,7 +4051,7 @@
               "        </style>\n",
               "      \n",
               "      <progress value='1602' max='1602' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-              "      [1602/1602 09:14, Epoch 6/6]\n",
+              "      [1602/1602 09:15, Epoch 6/6]\n",
               "    </div>\n",
               "    <table border=\"1\" class=\"dataframe\">\n",
               "  <thead>\n",
@@ -4036,35 +4063,35 @@
               "  <tbody>\n",
               "    <tr>\n",
               "      <td>200</td>\n",
-              "      <td>0.469576</td>\n",
+              "      <td>0.478168</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <td>400</td>\n",
-              "      <td>0.313648</td>\n",
+              "      <td>0.308236</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <td>600</td>\n",
-              "      <td>0.284003</td>\n",
+              "      <td>0.285305</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <td>800</td>\n",
-              "      <td>0.269178</td>\n",
+              "      <td>0.273353</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <td>1000</td>\n",
-              "      <td>0.246140</td>\n",
+              "      <td>0.249971</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <td>1200</td>\n",
-              "      <td>0.238821</td>\n",
+              "      <td>0.241900</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <td>1400</td>\n",
-              "      <td>0.228444</td>\n",
+              "      <td>0.229655</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <td>1600</td>\n",
-              "      <td>0.218775</td>\n",
+              "      <td>0.223346</td>\n",
               "    </tr>\n",
               "  </tbody>\n",
               "</table><p>"
@@ -4081,13 +4108,13 @@
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "TrainOutput(global_step=1602, training_loss=0.2833864400151666)"
+              "TrainOutput(global_step=1602, training_loss=0.28606768166378943)"
             ]
           },
           "metadata": {
             "tags": []
           },
-          "execution_count": 10
+          "execution_count": 8
         }
       ]
     },
@@ -4106,14 +4133,14 @@
         "id": "9PgHWEhsYeMv",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 55
+          "height": 92
         },
-        "outputId": "4d6ec6d0-a58d-4867-f9af-72ba6d899ff7"
+        "outputId": "48926480-846d-4600-a1f4-00426bc43121"
       },
       "source": [
         "trainer.evaluate()"
       ],
-      "execution_count": 11,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "display_data",
@@ -4148,13 +4175,15 @@
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "{'epoch': 6.0, 'eval_acc': 0.8874296435272045, 'eval_loss': 0.2794782519340515}"
+              "{'epoch': 6.0,\n",
+              " 'eval_acc': 0.8864915572232646,\n",
+              " 'eval_loss': 0.28223761916160583}"
             ]
           },
           "metadata": {
             "tags": []
           },
-          "execution_count": 11
+          "execution_count": 9
         }
       ]
     },
@@ -4174,7 +4203,7 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "d8292cbe-4e43-4303-cd38-ab6725646b7c"
+        "outputId": "adefb9cb-a435-476a-d836-e2336d45aa36"
       },
       "source": [
         " from transformers import TextClassificationPipeline\n",
@@ -4183,19 +4212,19 @@
         "\n",
         "classifier(\"This is awesome!\")"
       ],
-      "execution_count": 12,
+      "execution_count": 10,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "[{'label': 'LABEL_1', 'score': 0.9894435405731201}]"
+              "[{'label': '👍', 'score': 0.9855322241783142}]"
             ]
           },
           "metadata": {
             "tags": []
           },
-          "execution_count": 12
+          "execution_count": 10
         }
       ]
     },
@@ -4215,23 +4244,23 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "172395dd-4076-4045-b90d-9c7c817524c3"
+        "outputId": "17ff1895-2145-4cc7-9077-6d182e96741f"
       },
       "source": [
         "model.save_adapter(\"./final_adapter\", \"rotten_tomatoes\")\n",
         "\n",
         "!ls -lh final_adapter"
       ],
-      "execution_count": 13,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
             "total 5.8M\n",
-            "-rw-r--r-- 1 root root  631 Dec 15 16:57 adapter_config.json\n",
-            "-rw-r--r-- 1 root root  344 Dec 15 16:57 head_config.json\n",
-            "-rw-r--r-- 1 root root 3.5M Dec 15 16:57 pytorch_adapter.bin\n",
-            "-rw-r--r-- 1 root root 2.3M Dec 15 16:57 pytorch_model_head.bin\n"
+            "-rw-r--r-- 1 root root  631 Dec 17 11:05 adapter_config.json\n",
+            "-rw-r--r-- 1 root root  354 Dec 17 11:05 head_config.json\n",
+            "-rw-r--r-- 1 root root 3.5M Dec 17 11:05 pytorch_adapter.bin\n",
+            "-rw-r--r-- 1 root root 2.3M Dec 17 11:05 pytorch_model_head.bin\n"
           ],
           "name": "stdout"
         }


### PR DESCRIPTION
Quick fix for the adapter training notebook by explicitly avoiding the label columns to be removed by the HF Trainer. Diff is pretty ugly, the only relevant changes is the last arg in:

```python
training_args = TrainingArguments(
    learning_rate=1e-4,
    num_train_epochs=6,
    per_device_train_batch_size=32,
    per_device_eval_batch_size=32,
    logging_steps=200,
    output_dir="./training_output",
    overwrite_output_dir=True,
    # The next line is important to ensure the dataset labels are properly passed to the model
    remove_unused_columns=False,
)
```