### PR TITLE
Fixes for (re-)loading models with AdapterFusion

### DIFF
--- a/src/transformers/adapter_distilbert.py
+++ b/src/transformers/adapter_distilbert.py
@@ -7,7 +7,6 @@ from .adapter_bert import (
     BertOutputAdaptersMixin,
     BertSelfOutputAdaptersMixin,
 )
-from .adapter_config import DEFAULT_ADAPTER_CONFIG
 from .adapter_model_mixin import InvertibleAdaptersMixin, ModelAdaptersMixin
 from .adapter_utils import AdapterType, flatten_adapter_names
 
@@ -74,21 +73,6 @@ class DistilBertModelAdaptersMixin(InvertibleAdaptersMixin, ModelAdaptersMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def _init_adapter_modules(self):
-        super()._init_adapter_modules()
-
-        # language adapters
-        for language in self.config.adapters.adapter_list(AdapterType.text_lang):
-            self.transformer.add_adapter(language, AdapterType.text_lang)
-            self.add_invertible_lang_adapter(language)
-        # task adapters
-        for task in self.config.adapters.adapter_list(AdapterType.text_task):
-            self.transformer.add_adapter(task, AdapterType.text_task)
-        # fusion
-        if hasattr(self.config, "fusion_models"):
-            for fusion_adapter_names in self.config.fusion_models:
-                self.transformer.add_fusion_layer(fusion_adapter_names)
-
     def train_adapter(self, adapter_names: list):
         """Sets the model in mode for training the given adapters."""
         self.train()
@@ -108,24 +92,7 @@ class DistilBertModelAdaptersMixin(InvertibleAdaptersMixin, ModelAdaptersMixin):
         # use the adapters to be trained by default in every forward pass
         self.set_active_adapters(adapter_names)
 
-    def add_adapter(self, adapter_name: str, adapter_type: AdapterType, config=None):
-        """
-        Adds a new adapter module of the specified type to the model.
-
-        Args:
-            adapter_name (str): The name of the adapter module to be added.
-            adapter_type (AdapterType): The adapter type.
-            config (str or dict or AdapterConfig, optional): The adapter configuration, can be either:
-
-                - the string identifier of a pre-defined configuration dictionary
-                - a configuration dictionary specifying the full config
-                - if not given, the default configuration for this adapter type will be used
-        """
-        if not AdapterType.has(adapter_type):
-            raise ValueError("Invalid adapter type {}".format(adapter_type))
-        if not self.config.adapters.get_config(adapter_type):
-            self.config.adapters.set_config(adapter_type, config or DEFAULT_ADAPTER_CONFIG)
-        self.config.adapters.add(adapter_name, adapter_type, config=config)
+    def _add_adapter(self, adapter_name, adapter_type):
         self.transformer.add_adapter(adapter_name, adapter_type)
         if adapter_type == AdapterType.text_lang:
             self.add_invertible_lang_adapter(adapter_name)


### PR DESCRIPTION
Fix loading a full model with AdapterFusion (add a test case for this).
Pull _init_adapter_modules() to base mixin to remove redundancy for fusion/ adapter loading.
Add model-specific _add_adapter() method.
Change error for existing fusion config to warning to allow overriding identical fusion.