### PR TITLE
Fix sequence tagging flex head output with given labels.

### DIFF
--- a/src/transformers/adapter_heads.py
+++ b/src/transformers/adapter_heads.py
@@ -171,13 +171,13 @@ class TaggingHead(PredictionHead):
             # Only keep active parts of the loss
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
-                active_logits = logits.view(-1, self.num_labels)
+                active_logits = logits.view(-1, self.config["num_labels"])
                 active_labels = torch.where(
                     active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels)
                 )
                 loss = loss_fct(active_logits, active_labels)
             else:
-                loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
+                loss = loss_fct(logits.view(-1, self.config["num_labels"]), labels.view(-1))
 
         if return_dict:
             return TokenClassifierOutput(

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -959,10 +959,14 @@ class BertModelWithHeads(BertModelHeadsMixin, BertPreTrainedModel):
         else:
             head_inputs = outputs
 
-        head_outputs = self.forward_head(
-            head_inputs, head_name=head, attention_mask=attention_mask, return_dict=return_dict, **kwargs
-        )
-        return head_outputs
+        if head or self.active_head:
+            head_outputs = self.forward_head(
+                head_inputs, head_name=head, attention_mask=attention_mask, return_dict=return_dict, **kwargs
+            )
+            return head_outputs
+        else:
+            # in case no head is used just return the output of the base model (including pooler output)
+            return outputs
 
 
 @add_start_docstrings(

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -962,10 +962,6 @@ class BertModelWithHeads(BertModelHeadsMixin, BertPreTrainedModel):
         head_outputs = self.forward_head(
             head_inputs, head_name=head, attention_mask=attention_mask, return_dict=return_dict, **kwargs
         )
-        # plug pooler outputs back in
-        if not return_dict:
-            head_outputs = (head_outputs[0], outputs[1]) + head_outputs[1:]
-
         return head_outputs
 
 

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -813,10 +813,6 @@ class RobertaModelWithHeads(BertModelHeadsMixin, RobertaPreTrainedModel):
         head_outputs = self.forward_head(
             head_inputs, head_name=head, attention_mask=attention_mask, return_dict=return_dict, **kwargs
         )
-        # plug pooler outputs back in
-        if not return_dict:
-            head_outputs = (head_outputs[0], outputs[1]) + head_outputs[1:]
-
         return head_outputs
 
 

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -810,10 +810,14 @@ class RobertaModelWithHeads(BertModelHeadsMixin, RobertaPreTrainedModel):
         else:
             head_inputs = outputs
 
-        head_outputs = self.forward_head(
-            head_inputs, head_name=head, attention_mask=attention_mask, return_dict=return_dict, **kwargs
-        )
-        return head_outputs
+        if head or self.active_head:
+            head_outputs = self.forward_head(
+                head_inputs, head_name=head, attention_mask=attention_mask, return_dict=return_dict, **kwargs
+            )
+            return head_outputs
+        else:
+            # in case no head is used just return the output of the base model (including pooler output)
+            return outputs
 
 
 @add_start_docstrings(


### PR DESCRIPTION
Make sure changes in 34a0ccacdac96d7ce4402b20da1fa6cd3ce99010 work for models with and without prediction heads.
Add prediction head labels to flex head tests.