### PR TITLE
Enable parallel adapter inference together with attention_mask

### DIFF
--- a/src/transformers/adapter_distilbert.py
+++ b/src/transformers/adapter_distilbert.py
@@ -101,11 +101,6 @@ class DistilBertModelAdaptersMixin(InvertibleAdaptersMixin, ModelAdaptersMixin):
     def _add_fusion_layer(self, adapter_names):
         self.transformer.add_fusion_layer(adapter_names)
 
-    def pre_transformer_forward(self, hidden_states, *args):
-        hidden_states = self.invertible_adapters_forward(hidden_states)
-
-        return super().pre_transformer_forward(hidden_states, *args)
-
     def get_fusion_regularization_loss(self):
         reg_loss = 0.0
         target = torch.zeros((self.config.hidden_size, self.config.hidden_size)).fill_diagonal_(1.0).to(self.device)

--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -447,6 +447,8 @@ class RobertaEncoder(BertEncoderAdaptersMixin, nn.Module):
                     output_attentions,
                 )
             hidden_states = layer_outputs[0]
+            attention_mask = self.adjust_attention_mask_for_parallel(hidden_states, attention_mask)
+
             if output_attentions:
                 all_self_attentions = all_self_attentions + (layer_outputs[1],)
                 if self.config.add_cross_attention:
@@ -663,9 +665,7 @@ class RobertaModel(BertModelAdaptersMixin, RobertaPreTrainedModel):
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-        # some warnings if we don't use available adapters
-        if not self.active_adapters and self.has_adapters():
-            logger.warning("There are adapters available but none are passed to model.forward")
+        self.pre_transformer_forward()
 
         if input_ids is not None and inputs_embeds is not None:
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
@@ -678,21 +678,14 @@ class RobertaModel(BertModelAdaptersMixin, RobertaPreTrainedModel):
 
         device = input_ids.device if input_ids is not None else inputs_embeds.device
 
+        if attention_mask is None:
+            attention_mask = torch.ones(input_shape, device=device)
         if token_type_ids is None:
             token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
 
-        if self.has_parallel_adapters:
-            if attention_mask is not None:
-                raise ValueError("attention_mask cannot be used together with parallel adapter block.")
-            extended_attention_mask = None
-        else:
-            if attention_mask is None:
-                attention_mask = torch.ones(input_shape, device=device)
-            # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
-            # ourselves in which case we just need to make it broadcastable to all heads.
-            extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(
-                attention_mask, input_shape, device
-            )
+        # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
+        # ourselves in which case we just need to make it broadcastable to all heads.
+        extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(attention_mask, input_shape, device)
 
         # If a 2D or 3D attention mask is provided for the cross-attention
         # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
@@ -715,7 +708,7 @@ class RobertaModel(BertModelAdaptersMixin, RobertaPreTrainedModel):
         embedding_output = self.embeddings(
             input_ids=input_ids, position_ids=position_ids, token_type_ids=token_type_ids, inputs_embeds=inputs_embeds
         )
-        embedding_output = self.pre_transformer_forward(embedding_output)
+        embedding_output = self.invertible_adapters_forward(embedding_output)
 
         encoder_outputs = self.encoder(
             embedding_output,

--- a/tests/test_adapter_composition.py
+++ b/tests/test_adapter_composition.py
@@ -2,16 +2,11 @@ import unittest
 
 import torch
 
-from transformers import (
-    BertConfig,
-    BertForSequenceClassification,
-    BertModelWithHeads,
-    DistilBertModelWithHeads,
-    RobertaModelWithHeads,
-)
-from transformers.adapter_composition import Fuse, Parallel, Split, Stack, parse_composition
+from transformers import AutoModelWithHeads, BertConfig, BertForSequenceClassification
+from transformers.adapter_composition import SUPPORTED_MODELS, Fuse, Parallel, Split, Stack, parse_composition
 from transformers.testing_utils import require_torch, torch_device
 
+from .test_adapter_common import MODELS_WITH_ADAPTERS
 from .test_modeling_common import ids_tensor
 
 
@@ -103,22 +98,22 @@ class AdapterCompositionTest(unittest.TestCase):
 @require_torch
 class ParallelAdapterInferenceTest(unittest.TestCase):
 
-    model_classes = [BertModelWithHeads, RobertaModelWithHeads, DistilBertModelWithHeads]
+    model_config_creators = [v for k, v in MODELS_WITH_ADAPTERS.items() if k.model_type in SUPPORTED_MODELS[Parallel]]
 
     def test_parallel_inference_with_heads(self):
-        for model_class in self.model_classes:
-            model_config = model_class.config_class
-            model = model_class(model_config())
-            model.eval()
+        for config_creator in self.model_config_creators:
+            model = AutoModelWithHeads.from_config(config_creator())
 
             model.add_adapter("a")
             model.add_adapter("b")
             model.add_classification_head("a", num_labels=2)
             model.add_classification_head("b", num_labels=3)
 
-            with self.subTest(model_class=model_class.__name__):
+            model.eval()
+
+            with self.subTest(model_class=model.__class__.__name__):
                 inputs = {}
-                inputs["attention_mask"] = torch.ones((2, 128))
+                inputs["attention_mask"] = torch.randint(0, 2, size=(2, 128))
                 inputs["input_ids"] = ids_tensor((2, 128), 1000)
 
                 # for reference, pass through single adapters
@@ -136,20 +131,19 @@ class ParallelAdapterInferenceTest(unittest.TestCase):
                 self.assertEqual(len(outputs), 2)
                 self.assertEqual(outputs[0][0].shape, (2, 2))
                 self.assertEqual(outputs[1][0].shape, (2, 3))
-                self.assertTrue(torch.equal(outputs[0][0], outputs_a[0]))
-                self.assertTrue(torch.equal(outputs[1][0], outputs_b[0]))
+                self.assertTrue(torch.allclose(outputs[0][0], outputs_a[0]))
+                self.assertTrue(torch.allclose(outputs[1][0], outputs_b[0]))
 
     def test_parallel_inference_with_wrong_number_of_heads(self):
-        for model_class in self.model_classes:
-            model_config = model_class.config_class
-            model = model_class(model_config())
+        for config_creator in self.model_config_creators:
+            model = AutoModelWithHeads.from_config(config_creator())
             model.eval()
 
             model.add_adapter("a")
             model.add_adapter("b")
             model.add_classification_head("a", num_labels=2)
 
-            with self.subTest(model_class=model_class.__name__):
+            with self.subTest(model_class=model.__class__.__name__):
 
                 inputs = {}
                 inputs["input_ids"] = ids_tensor((2, 128), 1000)

--- a/tests/test_adapter_composition.py
+++ b/tests/test_adapter_composition.py
@@ -118,6 +118,7 @@ class ParallelAdapterInferenceTest(unittest.TestCase):
 
             with self.subTest(model_class=model_class.__name__):
                 inputs = {}
+                inputs["attention_mask"] = torch.ones((2, 128))
                 inputs["input_ids"] = ids_tensor((2, 128), 1000)
 
                 # for reference, pass through single adapters


### PR DESCRIPTION
Follow-up to #116:

In the current parallel inference implementation, it is not possible to set an attention mask at the same time, making parallel inference difficult to use in practice. This PR adds a new hook (`adjust_attention_mask_for_parallel()`) called after every Transformers layer that ensures that the attention mask is properly resized when the hidden states are.

This is enough to make it work for BERT, RoBERTa & DistilBERT, but the Parallel block might not be usable for other model types (e.g. BART). Therefore, I added a whitelist for this block in `adapter_composition.py`.