### PR TITLE
Add guide on how to add adapters to models

### DIFF
--- a/adding_adapters_to_a_model.md
+++ b/adding_adapters_to_a_model.md
@@ -25,7 +25,8 @@ This is the central module to implement.
     - Have a look at existing examples, e.g. `adapter_distilbert.py`, `adapter_bert.py`.
 - Implement the mixins on the modeling classes (`modeling_<model_type>.py`).
     - Make sure the calls to `adapters_forward()` are added in the right places.
-- Patch the model configuration `configuration_<model_type>` to correctly set the adapter configuration (`ModelAdaptersCondfig`).
+- Add the mixin for config classes, `ModelConfigAdaptersMixin`, to the model configuration class in `configuration_<model_type>`.
+    - There are some naming differences on the config attributes of different model architectures. The adapter implementation requires some additional attributes with a specific name to be available. These currently are `hidden_dropout_prob` and `attention_probs_dropout_prob` as in the `BertConfig` class.
 
 ❓ Adapter-supporting architectures have a new model class `<model_type>ModelWithHeads`.
 These classes allow flexible adding of and switching between multiple prediction heads of different types.

--- a/adding_adapters_to_a_model.md
+++ b/adding_adapters_to_a_model.md
@@ -54,3 +54,9 @@ These classes allow flexible adding of and switching between multiple prediction
 **📝 Steps**
 
 - Add `adapter_docs/classes/<model_type>.rst` (oriented at the doc file in the HF docs, make sure to include `<model_type>ModelWithHeads` and the HF notice, then show the file in the index).
+
+## Training Example Adapters
+
+❓ To make sure the new adapter implementation works properly, it is useful to train some example adapters and compare the training results to full model fine-tuning. Ideally, this would include training adapters on one (or more) tasks that are good for demonstrating the new model architecture (e.g. GLUE benchmark for BERT, summarization for BART) and uploading them to AdapterHub.
+
+HuggingFace already provides example training scripts for many tasks, some of them have already been modified to support adapter training (see https://github.com/Adapter-Hub/adapter-transformers/tree/master/examples).

--- a/src/transformers/adapter_model_mixin.py
+++ b/src/transformers/adapter_model_mixin.py
@@ -714,6 +714,26 @@ class InvertibleAdaptersMixin:
         return hidden_states
 
 
+class ModelConfigAdaptersMixin(ABC):
+    """
+    Mixin for model config classes, adding support for adapters.
+
+    Besides adding this mixin to the config class of a model supporting adapters,
+    make sure the following attributes/ properties are present:
+    hidden_dropout_prob, attention_probs_dropout_prob.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # adapter configuration
+        adapter_config_dict = kwargs.pop("adapters", None)
+        if adapter_config_dict:
+            self.adapters = ModelAdaptersConfig(**adapter_config_dict)
+        else:
+            self.adapters = ModelAdaptersConfig()
+
+
 class ModelAdaptersMixin(ABC):
     """Mixin for transformer models adding support for loading/ saving adapters."""
 

--- a/src/transformers/models/bert/configuration_bert.py
+++ b/src/transformers/models/bert/configuration_bert.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 """ BERT model configuration """
 
-from ...adapter_config import ModelAdaptersConfig
+from ...adapter_model_mixin import ModelConfigAdaptersMixin
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
 
@@ -49,7 +49,7 @@ BERT_PRETRAINED_CONFIG_ARCHIVE_MAP = {
 }
 
 
-class BertConfig(PretrainedConfig):
+class BertConfig(ModelConfigAdaptersMixin, PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a :class:`~transformers.BertModel` or a
     :class:`~transformers.TFBertModel`. It is used to instantiate a BERT model according to the specified arguments,
@@ -141,10 +141,3 @@ class BertConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.layer_norm_eps = layer_norm_eps
         self.gradient_checkpointing = gradient_checkpointing
-
-        # adapter configuration
-        adapter_config_dict = kwargs.pop("adapters", None)
-        if adapter_config_dict:
-            self.adapters = ModelAdaptersConfig(**adapter_config_dict)
-        else:
-            self.adapters = ModelAdaptersConfig()

--- a/src/transformers/models/distilbert/configuration_distilbert.py
+++ b/src/transformers/models/distilbert/configuration_distilbert.py
@@ -15,7 +15,7 @@
 """ DistilBERT model configuration """
 
 
-from ...adapter_config import ModelAdaptersConfig
+from ...adapter_model_mixin import ModelConfigAdaptersMixin
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
 
@@ -33,7 +33,7 @@ DISTILBERT_PRETRAINED_CONFIG_ARCHIVE_MAP = {
 }
 
 
-class DistilBertConfig(PretrainedConfig):
+class DistilBertConfig(ModelConfigAdaptersMixin, PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a :class:`~transformers.DistilBertModel` or a
     :class:`~transformers.TFDistilBertModel`. It is used to instantiate a DistilBERT model according to the specified
@@ -125,13 +125,6 @@ class DistilBertConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.qa_dropout = qa_dropout
         self.seq_classif_dropout = seq_classif_dropout
-
-        # adapter configuration
-        adapter_config_dict = kwargs.pop("adapters", None)
-        if adapter_config_dict:
-            self.adapters = ModelAdaptersConfig(**adapter_config_dict)
-        else:
-            self.adapters = ModelAdaptersConfig()
 
     @property
     def hidden_size(self):


### PR DESCRIPTION
Drafted a step-by-step guide on how adapters are added to model classes. This might be useful for us to follow when adding new models and it might also serve as a starting point for external contributors.

@hSterz Please check and comment how well this fits with GPT-2.