### PR TITLE
Flex head implementation refactorings

### DIFF
--- a/src/transformers/adapter_bart.py
+++ b/src/transformers/adapter_bart.py
@@ -222,47 +222,14 @@ class BartModelAdaptersMixin(ModelAdaptersMixin):
 
 
 class BartModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
-    """Adds flexible heads to a BART model."""
-
-    def add_prediction_head_from_config(self, head_name, config, overwrite_ok=False):
-        id2label = (
-            {id_: label for label, id_ in config["label2id"].items()}
-            if "label2id" in config.keys() and config["label2id"]
-            else None
-        )
-        if config["head_type"] == "classification":
-            self.add_classification_head(
-                head_name,
-                config["num_labels"],
-                config["layers"],
-                config["activation_function"],
-                id2label=id2label,
-                overwrite_ok=overwrite_ok,
-            )
-        elif config["head_type"] == "multilabel_classification":
-            self.add_classification_head(
-                head_name,
-                config["num_labels"],
-                config["layers"],
-                config["activation_function"],
-                multilabel=True,
-                id2label=id2label,
-                overwrite_ok=overwrite_ok,
-            )
-        elif config["head_type"] == "question_answering":
-            self.add_qa_head(
-                head_name,
-                config["num_labels"],
-                config["layers"],
-                config["activation_function"],
-                id2label=id2label,
-                overwrite_ok=overwrite_ok,
-            )
-        else:
-            if config["head_type"] in self.config.custom_heads:
-                self.add_custom_head(head_name, config, overwrite_ok=overwrite_ok)
-            else:
-                raise AttributeError("Please register the PredictionHead before loading the model")
+    """
+    Adds flexible heads to a BART model.
+    """
+    head_types = {
+        "classification": ClassificationHead,
+        "multilabel_classification": MultiLabelClassificationHead,
+        "question_answering": QuestionAnsweringHead,
+    }
 
     def add_classification_head(
         self,
@@ -287,9 +254,9 @@ class BartModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
         """
 
         if multilabel:
-            head = MultiLabelClassificationHead(head_name, num_labels, layers, activation_function, id2label, self)
+            head = MultiLabelClassificationHead(self, head_name, num_labels, layers, activation_function, id2label)
         else:
-            head = ClassificationHead(head_name, num_labels, layers, activation_function, id2label, self)
+            head = ClassificationHead(self, head_name, num_labels, layers, activation_function, id2label)
         self.add_prediction_head(head, overwrite_ok)
 
     def add_qa_head(
@@ -301,5 +268,5 @@ class BartModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
         overwrite_ok=False,
         id2label=None,
     ):
-        head = QuestionAnsweringHead(head_name, num_labels, layers, activation_function, id2label, self)
+        head = QuestionAnsweringHead(self, head_name, num_labels, layers, activation_function, id2label)
         self.add_prediction_head(head, overwrite_ok)

--- a/src/transformers/adapter_bart.py
+++ b/src/transformers/adapter_bart.py
@@ -225,6 +225,7 @@ class BartModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
     """
     Adds flexible heads to a BART model.
     """
+
     head_types = {
         "classification": ClassificationHead,
         "multilabel_classification": MultiLabelClassificationHead,

--- a/src/transformers/adapter_bert.py
+++ b/src/transformers/adapter_bert.py
@@ -464,65 +464,16 @@ class BertModelAdaptersMixin(InvertibleAdaptersMixin, ModelAdaptersMixin):
 
 
 class BertModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
-    """Adds flexible heads to a BERT-based model class."""
-
-    def add_prediction_head_from_config(self, head_name, config, overwrite_ok=False):
-        id2label = (
-            {id_: label for label, id_ in config["label2id"].items()}
-            if "label2id" in config.keys() and config["label2id"]
-            else None
-        )
-        if config["head_type"] == "classification":
-            self.add_classification_head(
-                head_name,
-                config["num_labels"],
-                config["layers"],
-                config["activation_function"],
-                id2label=id2label,
-                overwrite_ok=overwrite_ok,
-            )
-        elif config["head_type"] == "multilabel_classification":
-            self.add_classification_head(
-                head_name,
-                config["num_labels"],
-                config["layers"],
-                config["activation_function"],
-                multilabel=True,
-                id2label=id2label,
-                overwrite_ok=overwrite_ok,
-            )
-        elif config["head_type"] == "tagging":
-            self.add_tagging_head(
-                head_name,
-                config["num_labels"],
-                config["layers"],
-                config["activation_function"],
-                id2label=id2label,
-                overwrite_ok=overwrite_ok,
-            )
-        elif config["head_type"] == "multiple_choice":
-            self.add_multiple_choice_head(
-                head_name,
-                config["num_choices"],
-                config["layers"],
-                config["activation_function"],
-                id2label=id2label,
-                overwrite_ok=overwrite_ok,
-            )
-        elif config["head_type"] == "question_answering":
-            self.add_qa_head(
-                head_name,
-                config["num_labels"],
-                config["layers"],
-                config["activation_function"],
-                id2label=id2label,
-                overwrite_ok=overwrite_ok,
-            )
-        else:
-            if config["head_type"] in self.config.custom_heads:
-                self.add_custom_head(head_name, config, overwrite_ok=overwrite_ok)
-            else:
-                raise AttributeError("Please register the PredictionHead before loading the model")
+    """
+    Adds flexible heads to a BERT-based model class.
+    """
+    head_types = {
+        "classification": ClassificationHead,
+        "multilabel_classification": MultiLabelClassificationHead,
+        "tagging": TaggingHead,
+        "multiple_choice": MultipleChoiceHead,
+        "question_answering": QuestionAnsweringHead,
+    }
 
     def add_classification_head(
         self,
@@ -546,9 +497,9 @@ class BertModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
         """
 
         if multilabel:
-            head = MultiLabelClassificationHead(head_name, num_labels, layers, activation_function, id2label, self)
+            head = MultiLabelClassificationHead(self, head_name, num_labels, layers, activation_function, id2label)
         else:
-            head = ClassificationHead(head_name, num_labels, layers, activation_function, id2label, self)
+            head = ClassificationHead(self, head_name, num_labels, layers, activation_function, id2label)
         self.add_prediction_head(head, overwrite_ok)
 
     def add_multiple_choice_head(
@@ -563,7 +514,7 @@ class BertModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
             activation_function (str, optional): Activation function. Defaults to 'tanh'.
             overwrite_ok (bool, optional): Force overwrite if a head with the same name exists. Defaults to False.
         """
-        head = MultipleChoiceHead(head_name, num_choices, layers, activation_function, id2label, self)
+        head = MultipleChoiceHead(self, head_name, num_choices, layers, activation_function, id2label)
         self.add_prediction_head(head, overwrite_ok)
 
     def add_tagging_head(
@@ -578,11 +529,11 @@ class BertModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
             activation_function (str, optional): Activation function. Defaults to 'tanh'.
             overwrite_ok (bool, optional): Force overwrite if a head with the same name exists. Defaults to False.
         """
-        head = TaggingHead(head_name, num_labels, layers, activation_function, id2label, self)
+        head = TaggingHead(self, head_name, num_labels, layers, activation_function, id2label)
         self.add_prediction_head(head, overwrite_ok)
 
     def add_qa_head(
         self, head_name, num_labels=2, layers=1, activation_function="tanh", overwrite_ok=False, id2label=None
     ):
-        head = QuestionAnsweringHead(head_name, num_labels, layers, activation_function, id2label, self)
+        head = QuestionAnsweringHead(self, head_name, num_labels, layers, activation_function, id2label)
         self.add_prediction_head(head, overwrite_ok)

--- a/src/transformers/adapter_bert.py
+++ b/src/transformers/adapter_bert.py
@@ -467,6 +467,7 @@ class BertModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
     """
     Adds flexible heads to a BERT-based model class.
     """
+
     head_types = {
         "classification": ClassificationHead,
         "multilabel_classification": MultiLabelClassificationHead,


### PR DESCRIPTION
Now, the prediction heads supported by a specific model are listed in the `head_types ` dictionary of the heads mixin. The model implementation don't have to implement `add_prediction_head_from_config()` anymore.