### PR TITLE
Add support for loading adapters from HuggingFace Model Hub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ _deps = [
     "flake8>=3.8.3",
     "flax>=0.3.2",
     "fugashi>=1.0",
+    "huggingface_hub>=0.0.8",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "isort>=5.5.4",
@@ -303,6 +304,7 @@ install_requires = [
     deps["dataclasses"] + ";python_version<'3.7'",  # dataclasses for Python versions that don't have it
     deps["importlib_metadata"] + ";python_version<'3.8'",  # importlib_metadata for Python versions that don't have it
     deps["filelock"],  # filesystem locks, e.g., to prevent parallel downloads
+    deps["huggingface_hub"],  # loading adapters from HF hub
     deps["numpy"],
     deps["packaging"],  # utilities from PyPA to e.g., compare versions
     deps["regex"],  # for OpenAI GPT

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ _deps = [
     "flake8>=3.8.3",
     "flax>=0.3.2",
     "fugashi>=1.0",
-    "huggingface_hub>=0.0.8",
+    "huggingface_hub>=0.0.9",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "isort>=5.5.4",

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -317,7 +317,7 @@ class ModelAdaptersMixin(ABC):
         version: str = None,
         model_name: str = None,
         load_as: str = None,
-        source: str = "adapterhub",
+        source: str = "ah",
         custom_weights_loaders: Optional[List[WeightsLoader]] = None,
         **kwargs
     ) -> str:
@@ -339,8 +339,8 @@ class ModelAdaptersMixin(ABC):
                     saved will be used.
             source (str, optional): Identifier of the source(s) from where to load the adapter. Can be:
 
-                - "adapterhub" (default): search on AdapterHub.
-                - "huggingface": search on HuggingFace model hub.
+                - "ah" (default): search on AdapterHub.
+                - "hf": search on HuggingFace model hub.
                 - None: only search on local file system
 
         Returns:
@@ -523,7 +523,7 @@ class ModelWithHeadsAdaptersMixin(ModelAdaptersMixin):
         version: str = None,
         model_name: str = None,
         load_as: str = None,
-        source: str = "adapterhub",
+        source: str = "ah",
         with_head: bool = True,
         custom_weights_loaders: Optional[List[WeightsLoader]] = None,
         **kwargs

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -317,6 +317,7 @@ class ModelAdaptersMixin(ABC):
         version: str = None,
         model_name: str = None,
         load_as: str = None,
+        source: str = "adapterhub",
         custom_weights_loaders: Optional[List[WeightsLoader]] = None,
         **kwargs
     ) -> str:
@@ -336,12 +337,19 @@ class ModelAdaptersMixin(ABC):
             model_name (str, optional): The string identifier of the pre-trained model.
             load_as (str, optional): Load the adapter using this name. By default, the name with which the adapter was
                     saved will be used.
+            source (str, optional): Identifier of the source(s) from where to load the adapter. Can be:
+
+                - "adapterhub" (default): search on AdapterHub.
+                - "huggingface": search on HuggingFace model hub.
+                - None: only search on local file system
 
         Returns:
             str: The name with which the adapter was added to the model.
         """
         loader = AdapterLoader(self)
-        load_dir, load_name = loader.load(adapter_name_or_path, config, version, model_name, load_as, **kwargs)
+        load_dir, load_name = loader.load(
+            adapter_name_or_path, config, version, model_name, load_as, source=source, **kwargs
+        )
         # load additional custom weights
         if custom_weights_loaders:
             for weights_loader in custom_weights_loaders:
@@ -515,6 +523,7 @@ class ModelWithHeadsAdaptersMixin(ModelAdaptersMixin):
         version: str = None,
         model_name: str = None,
         load_as: str = None,
+        source: str = "adapterhub",
         with_head: bool = True,
         custom_weights_loaders: Optional[List[WeightsLoader]] = None,
         **kwargs
@@ -529,6 +538,7 @@ class ModelWithHeadsAdaptersMixin(ModelAdaptersMixin):
             version=version,
             model_name=model_name,
             load_as=load_as,
+            source=source,
             custom_weights_loaders=custom_weights_loaders,
             **kwargs,
         )

--- a/src/transformers/adapters/utils.py
+++ b/src/transformers/adapters/utils.py
@@ -17,6 +17,7 @@ import requests
 from filelock import FileLock
 from huggingface_hub import snapshot_download
 
+from .. import __version__
 from ..file_utils import get_from_cache, is_remote_url, torch_cache_home
 
 
@@ -357,7 +358,13 @@ def pull_from_hub(
 
 
 def pull_from_hf_model_hub(specifier: str, version: str = None, **kwargs) -> str:
-    download_path = snapshot_download(specifier, revision=version, cache_dir=kwargs.pop("cache_dir", None))
+    download_path = snapshot_download(
+        specifier,
+        revision=version,
+        cache_dir=kwargs.pop("cache_dir", None),
+        library_name="adapter-transformers",
+        library_version=__version__,
+    )
     return download_path
 
 

--- a/src/transformers/adapters/utils.py
+++ b/src/transformers/adapters/utils.py
@@ -366,7 +366,7 @@ def resolve_adapter_path(
     model_name: str = None,
     adapter_config: Union[dict, str] = None,
     version: str = None,
-    source: str = "adapterhub",
+    source: str = "ah",
     **kwargs
 ) -> str:
     """
@@ -404,11 +404,11 @@ def resolve_adapter_path(
                     WEIGHTS_NAME, CONFIG_NAME, adapter_name_or_path
                 )
             )
-    elif source == "adapterhub":
+    elif source == "ah":
         return pull_from_hub(
             adapter_name_or_path, model_name, adapter_config=adapter_config, version=version, **kwargs
         )
-    elif source == "huggingface":
+    elif source == "hf":
         return pull_from_hf_model_hub(adapter_name_or_path, version=version, **kwargs)
     else:
         raise ValueError("Unable to identify {} as a valid module location.".format(adapter_name_or_path))

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -2,7 +2,7 @@
 # 1. modify the `_deps` dict in setup.py
 # 2. run `make deps_table_update``
 deps = {
-    "black": "black>=20.8b1",
+    "black": "black==20.8b1",
     "cookiecutter": "cookiecutter==1.7.2",
     "dataclasses": "dataclasses",
     "datasets": "datasets",
@@ -13,6 +13,7 @@ deps = {
     "flake8": "flake8>=3.8.3",
     "flax": "flax>=0.3.2",
     "fugashi": "fugashi>=1.0",
+    "huggingface_hub": "huggingface_hub>=0.0.8",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "isort": "isort>=5.5.4",
@@ -44,6 +45,7 @@ deps = {
     "sphinx-copybutton": "sphinx-copybutton",
     "sphinx-markdown-tables": "sphinx-markdown-tables",
     "sphinx-rtd-theme": "sphinx-rtd-theme==0.4.3",
+    "sphinxext-opengraph": "sphinxext-opengraph==0.4.1",
     "sphinx": "sphinx==3.2.1",
     "starlette": "starlette",
     "tensorflow-cpu": "tensorflow-cpu>=2.3",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -13,7 +13,7 @@ deps = {
     "flake8": "flake8>=3.8.3",
     "flax": "flax>=0.3.2",
     "fugashi": "fugashi>=1.0",
-    "huggingface_hub": "huggingface_hub>=0.0.8",
+    "huggingface_hub": "huggingface_hub>=0.0.9",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "isort": "isort>=5.5.4",


### PR DESCRIPTION
WIP for adding HuggingFace's model hub as a second source for loading adapters. Implementation via https://github.com/huggingface/huggingface_hub.

## Example

Adapter: https://huggingface.co/calpt/adapter-bert-base-squad1

### Loading from HF Hub

```python
model = BertForSequenceClassification.from_pretrained("bert-base-uncased")
model.load_adapter("calpt/adapter-bert-base-squad1", source="hf")
```

### Loading (the same adapter) from AdapterHub
```python
model = BertForSequenceClassification.from_pretrained("bert-base-uncased")
model.load_adapter("squad1", config="houlsby", source="ah")  # source="ah" is default & can be omitted
```