### PR TITLE
Re-add adapter_names argument

### DIFF
--- a/adapter_docs/v2_transition.md
+++ b/adapter_docs/v2_transition.md
@@ -86,13 +86,13 @@ model.add_adapter("name", AdapterType.text_task, config="pfeiffer")
 model.add_adapter("name", config="pfeiffer+inv")
 ```
 
-### Removal of `adapter_names` parameter in model forward()
+### Changes to `adapter_names` parameter in model forward()
 
-_Includes breaking changes ⚠️_
+_Includes breaking changes (only in v2.0.0, see note) ⚠️_
 
-In v1, it was possible to specify the active adapters using the `adapter_names` parameter in each call to the model's `forward()` method.
-With the integration of the new, unified mechanism for specifying adapter setups using composition blocks, this parameter was dropped.
-The active adapters now are exclusively set via `set_active_adapters()` or the `active_adapters` property.
+One possibility to specify the active adapters is to use the `adapter_names` parameter in each call to the model's `forward()` method.
+With the integration of the new, unified mechanism for specifying adapter setups using composition blocks,
+it is now recommended to specify the active adapters via `set_active_adapters()` or the `active_adapters` property.
 For example...
 
 ```python
@@ -104,6 +104,14 @@ model(**input_data, adapter_names="awesome_adapter")
 # NEW (v2)
 model.active_adapters = "awesome_adapter"
 model(**input_data)
+```
+
+```eval_rst
+.. note::
+    Version 2.0.0 temporarily removed the ``adapter_names`` parameter entirely.
+    Due to user feedback regarding limitations of the ``active_adapters`` property in multi-threaded contexts,
+    the ``adapter_names`` parameter was **re-added in v2.0.1**.
+    See `here for more <https://github.com/Adapter-Hub/adapter-transformers/issues/165>`_.
 ```
 
 ## Internal changes

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -2,7 +2,7 @@
 # 1. modify the `_deps` dict in setup.py
 # 2. run `make deps_table_update``
 deps = {
-    "black": "black>=20.8b1",
+    "black": "black==20.8b1",
     "cookiecutter": "cookiecutter==1.7.2",
     "dataclasses": "dataclasses",
     "datasets": "datasets",
@@ -44,6 +44,7 @@ deps = {
     "sphinx-copybutton": "sphinx-copybutton",
     "sphinx-markdown-tables": "sphinx-markdown-tables",
     "sphinx-rtd-theme": "sphinx-rtd-theme==0.4.3",
+    "sphinxext-opengraph": "sphinxext-opengraph==0.4.1",
     "sphinx": "sphinx==3.2.1",
     "starlette": "starlette",
     "tensorflow-cpu": "tensorflow-cpu>=2.3",

--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -807,7 +807,6 @@ class BartEncoder(InvertibleAdaptersMixin, BartEncoderDecoderAdaptersMixin, Bart
                         hidden_states,
                         attention_mask,
                         (head_mask[idx] if head_mask is not None else None),
-                        **kwargs,
                     )
                 else:
                     layer_outputs = encoder_layer(
@@ -1057,7 +1056,6 @@ class BartDecoder(BartEncoderDecoderAdaptersMixin, BartPretrainedModel):
                     head_mask[idx] if head_mask is not None else None,
                     encoder_head_mask[idx] if encoder_head_mask is not None else None,
                     None,
-                    **kwargs,
                 )
             else:
 

--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -1376,6 +1376,7 @@ class BartForConditionalGeneration(ModelWithHeadsAdaptersMixin, BartPretrainedMo
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
@@ -1408,6 +1409,7 @@ class BartForConditionalGeneration(ModelWithHeadsAdaptersMixin, BartPretrainedMo
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         lm_logits = self.model.encoder.invertible_adapters_forward(outputs[0], rev=True)
         lm_logits = self.lm_head(lm_logits) + self.final_logits_bias
@@ -1514,6 +1516,7 @@ class BartForSequenceClassification(ModelWithHeadsAdaptersMixin, BartPretrainedM
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1543,6 +1546,7 @@ class BartForSequenceClassification(ModelWithHeadsAdaptersMixin, BartPretrainedM
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         hidden_states = outputs[0]  # last hidden state
 
@@ -1621,6 +1625,7 @@ class BartForQuestionAnswering(ModelWithHeadsAdaptersMixin, BartPretrainedModel)
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         start_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1650,6 +1655,7 @@ class BartForQuestionAnswering(ModelWithHeadsAdaptersMixin, BartPretrainedModel)
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         sequence_output = outputs[0]
@@ -1763,6 +1769,7 @@ class BartForCausalLM(ModelWithHeadsAdaptersMixin, BartPretrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         Args:
@@ -1863,6 +1870,7 @@ class BartForCausalLM(ModelWithHeadsAdaptersMixin, BartPretrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         logits = self.lm_head(outputs[0])

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -582,7 +582,6 @@ class BertEncoder(BertEncoderAdaptersMixin, nn.Module):
                     layer_head_mask,
                     encoder_hidden_states,
                     encoder_attention_mask,
-                    **kwargs,
                 )
             else:
                 layer_outputs = layer_module(

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -1135,6 +1135,7 @@ class BertForPreTraining(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape ``(batch_size, sequence_length)``, `optional`):
@@ -1178,6 +1179,7 @@ class BertForPreTraining(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         sequence_output, pooled_output = outputs[:2]
@@ -1250,6 +1252,7 @@ class BertLMHeadModel(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         encoder_hidden_states  (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, hidden_size)`, `optional`):
@@ -1310,6 +1313,7 @@ class BertLMHeadModel(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         sequence_output = outputs[0]
@@ -1405,6 +1409,7 @@ class BertForMaskedLM(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
@@ -1427,6 +1432,7 @@ class BertForMaskedLM(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         sequence_output = outputs[0]
@@ -1493,6 +1499,7 @@ class BertForNextSentencePrediction(ModelWithHeadsAdaptersMixin, BertPreTrainedM
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
         **kwargs
     ):
         r"""
@@ -1541,6 +1548,7 @@ class BertForNextSentencePrediction(ModelWithHeadsAdaptersMixin, BertPreTrainedM
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         pooled_output = outputs[1]
@@ -1601,6 +1609,7 @@ class BertForSequenceClassification(ModelWithHeadsAdaptersMixin, BertPreTrainedM
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1620,6 +1629,7 @@ class BertForSequenceClassification(ModelWithHeadsAdaptersMixin, BertPreTrainedM
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         pooled_output = outputs[1]
@@ -1685,6 +1695,7 @@ class BertForMultipleChoice(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1715,6 +1726,7 @@ class BertForMultipleChoice(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         pooled_output = outputs[1]
@@ -1780,6 +1792,7 @@ class BertForTokenClassification(ModelWithHeadsAdaptersMixin, BertPreTrainedMode
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
@@ -1798,6 +1811,7 @@ class BertForTokenClassification(ModelWithHeadsAdaptersMixin, BertPreTrainedMode
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         sequence_output = outputs[0]
@@ -1871,6 +1885,7 @@ class BertForQuestionAnswering(ModelWithHeadsAdaptersMixin, BertPreTrainedModel)
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         start_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1894,6 +1909,7 @@ class BertForQuestionAnswering(ModelWithHeadsAdaptersMixin, BertPreTrainedModel)
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         sequence_output = outputs[0]

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -354,10 +354,10 @@ class BertSelfOutput(BertSelfOutputAdaptersMixin, nn.Module):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self._init_adapter_modules()
 
-    def forward(self, hidden_states, input_tensor):
+    def forward(self, hidden_states, input_tensor, **kwargs):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.dropout(hidden_states)
-        hidden_states = self.adapters_forward(hidden_states, input_tensor)
+        hidden_states = self.adapters_forward(hidden_states, input_tensor, **kwargs)
         return hidden_states
 
 
@@ -395,6 +395,7 @@ class BertAttention(nn.Module):
         encoder_attention_mask=None,
         past_key_value=None,
         output_attentions=False,
+        **kwargs
     ):
         self_outputs = self.self(
             hidden_states,
@@ -405,7 +406,7 @@ class BertAttention(nn.Module):
             past_key_value,
             output_attentions,
         )
-        attention_output = self.output(self_outputs[0], hidden_states)
+        attention_output = self.output(self_outputs[0], hidden_states, **kwargs)
         outputs = (attention_output,) + self_outputs[1:]  # add attentions if we output them
         return outputs
 
@@ -435,10 +436,10 @@ class BertOutput(BertOutputAdaptersMixin, nn.Module):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self._init_adapter_modules()
 
-    def forward(self, hidden_states, input_tensor):
+    def forward(self, hidden_states, input_tensor, **kwargs):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.dropout(hidden_states)
-        hidden_states = self.adapters_forward(hidden_states, input_tensor)
+        hidden_states = self.adapters_forward(hidden_states, input_tensor, **kwargs)
         return hidden_states
 
 
@@ -465,6 +466,7 @@ class BertLayer(BertLayerAdaptersMixin, nn.Module):
         encoder_attention_mask=None,
         past_key_value=None,
         output_attentions=False,
+        **kwargs
     ):
         # decoder uni-directional self-attention cached key/values tuple is at positions 1,2
         self_attn_past_key_value = past_key_value[:2] if past_key_value is not None else None
@@ -474,6 +476,7 @@ class BertLayer(BertLayerAdaptersMixin, nn.Module):
             head_mask,
             output_attentions=output_attentions,
             past_key_value=self_attn_past_key_value,
+            **kwargs,
         )
         attention_output = self_attention_outputs[0]
 
@@ -509,7 +512,7 @@ class BertLayer(BertLayerAdaptersMixin, nn.Module):
             present_key_value = present_key_value + cross_attn_present_key_value
 
         layer_output = apply_chunking_to_forward(
-            self.feed_forward_chunk, self.chunk_size_feed_forward, self.seq_len_dim, attention_output
+            self.feed_forward_chunk, self.chunk_size_feed_forward, self.seq_len_dim, attention_output, **kwargs
         )
         outputs = (layer_output,) + outputs
 
@@ -519,9 +522,9 @@ class BertLayer(BertLayerAdaptersMixin, nn.Module):
 
         return outputs
 
-    def feed_forward_chunk(self, attention_output):
+    def feed_forward_chunk(self, attention_output, **kwargs):
         intermediate_output = self.intermediate(attention_output)
-        layer_output = self.output(intermediate_output, attention_output)
+        layer_output = self.output(intermediate_output, attention_output, **kwargs)
         return layer_output
 
 
@@ -543,6 +546,7 @@ class BertEncoder(BertEncoderAdaptersMixin, nn.Module):
         output_attentions=False,
         output_hidden_states=False,
         return_dict=True,
+        **kwargs
     ):
         all_hidden_states = () if output_hidden_states else None
         all_self_attentions = () if output_attentions else None
@@ -578,6 +582,7 @@ class BertEncoder(BertEncoderAdaptersMixin, nn.Module):
                     layer_head_mask,
                     encoder_hidden_states,
                     encoder_attention_mask,
+                    **kwargs,
                 )
             else:
                 layer_outputs = layer_module(
@@ -588,6 +593,7 @@ class BertEncoder(BertEncoderAdaptersMixin, nn.Module):
                     encoder_attention_mask,
                     past_key_value,
                     output_attentions,
+                    **kwargs,
                 )
 
             hidden_states = layer_outputs[0]
@@ -907,6 +913,7 @@ class BertModel(BertModelAdaptersMixin, BertPreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        **kwargs
     ):
         r"""
         encoder_hidden_states  (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, hidden_size)`, `optional`):
@@ -1003,6 +1010,7 @@ class BertModel(BertModelAdaptersMixin, BertPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            **kwargs,
         )
         sequence_output = encoder_outputs[0]
         pooled_output = self.pooler(sequence_output) if self.pooler is not None else None
@@ -1045,8 +1053,9 @@ class BertModelWithHeads(BertModelHeadsMixin, BertPreTrainedModel):
         inputs_embeds=None,
         output_attentions=None,
         output_hidden_states=None,
-        head=None,
         return_dict=None,
+        adapter_names=None,
+        head=None,
         **kwargs
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -1071,6 +1080,7 @@ class BertModelWithHeads(BertModelHeadsMixin, BertPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:

--- a/src/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_distilbert.py
@@ -618,6 +618,7 @@ class DistilBertForMaskedLM(ModelWithHeadsAdaptersMixin, DistilBertPreTrainedMod
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
@@ -635,6 +636,7 @@ class DistilBertForMaskedLM(ModelWithHeadsAdaptersMixin, DistilBertPreTrainedMod
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         hidden_states = dlbrt_output[0]  # (bs, seq_length, dim)
         prediction_logits = self.vocab_transform(hidden_states)  # (bs, seq_length, dim)
@@ -695,6 +697,7 @@ class DistilBertForSequenceClassification(ModelWithHeadsAdaptersMixin, DistilBer
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -712,6 +715,7 @@ class DistilBertForSequenceClassification(ModelWithHeadsAdaptersMixin, DistilBer
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         hidden_state = distilbert_output[0]  # (bs, seq_len, dim)
         pooled_output = hidden_state[:, 0]  # (bs, dim)
@@ -777,6 +781,7 @@ class DistilBertForQuestionAnswering(ModelWithHeadsAdaptersMixin, DistilBertPreT
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         start_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -798,6 +803,7 @@ class DistilBertForQuestionAnswering(ModelWithHeadsAdaptersMixin, DistilBertPreT
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         hidden_states = distilbert_output[0]  # (bs, max_query_len, dim)
 
@@ -872,6 +878,7 @@ class DistilBertForTokenClassification(ModelWithHeadsAdaptersMixin, DistilBertPr
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
@@ -888,6 +895,7 @@ class DistilBertForTokenClassification(ModelWithHeadsAdaptersMixin, DistilBertPr
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         sequence_output = outputs[0]
@@ -953,6 +961,7 @@ class DistilBertForMultipleChoice(ModelWithHeadsAdaptersMixin, DistilBertPreTrai
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1001,6 +1010,7 @@ class DistilBertForMultipleChoice(ModelWithHeadsAdaptersMixin, DistilBertPreTrai
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         hidden_state = outputs[0]  # (bs * num_choices, seq_len, dim)

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -290,6 +290,7 @@ class Block(GPT2DecoderBlockAdaptersMixin, nn.Module):
         encoder_attention_mask=None,
         use_cache=False,
         output_attentions=False,
+        **kwargs
     ):
         attn_outputs = self.attn(
             self.ln_1(hidden_states),
@@ -301,7 +302,7 @@ class Block(GPT2DecoderBlockAdaptersMixin, nn.Module):
         )
         attn_output = attn_outputs[0]  # output_attn: a, present, (attentions)
         outputs = attn_outputs[1:]
-        hidden_states = self.attention_adapters.adapters_forward(attn_output, hidden_states)
+        hidden_states = self.attention_adapters.adapters_forward(attn_output, hidden_states, **kwargs)
 
         if encoder_hidden_states is not None:
             # add one self-attention block for cross-attention
@@ -325,7 +326,7 @@ class Block(GPT2DecoderBlockAdaptersMixin, nn.Module):
 
         feed_forward_hidden_states = self.mlp(self.ln_2(hidden_states))
 
-        hidden_states = self.output_adapters.adapters_forward(feed_forward_hidden_states, hidden_states)
+        hidden_states = self.output_adapters.adapters_forward(feed_forward_hidden_states, hidden_states, **kwargs)
 
         if use_cache:
             outputs = (hidden_states,) + outputs
@@ -624,6 +625,7 @@ class GPT2Model(GPT2ModelAdapterMixin, GPT2PreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        **kwargs
     ):
         self.pre_transformer_forward()
 
@@ -755,6 +757,7 @@ class GPT2Model(GPT2ModelAdapterMixin, GPT2PreTrainedModel):
                     head_mask[i],
                     encoder_hidden_states,
                     encoder_attention_mask,
+                    **kwargs,
                 )
             else:
                 outputs = block(
@@ -766,6 +769,7 @@ class GPT2Model(GPT2ModelAdapterMixin, GPT2PreTrainedModel):
                     encoder_attention_mask=encoder_attention_mask,
                     use_cache=use_cache,
                     output_attentions=output_attentions,
+                    **kwargs,
                 )
 
             hidden_states = outputs[0]
@@ -1332,8 +1336,9 @@ class GPT2ModelWithHeads(GPT2ModelHeadsMixin, GPT2PreTrainedModel):
         inputs_embeds=None,
         output_attentions=None,
         output_hidden_states=None,
-        head=None,
         return_dict=None,
+        adapter_names=None,
+        head=None,
         **kwargs
     ):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -1348,6 +1353,7 @@ class GPT2ModelWithHeads(GPT2ModelHeadsMixin, GPT2PreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         batch_size = outputs[0].shape[0]

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -757,7 +757,6 @@ class GPT2Model(GPT2ModelAdapterMixin, GPT2PreTrainedModel):
                     head_mask[i],
                     encoder_hidden_states,
                     encoder_attention_mask,
-                    **kwargs,
                 )
             else:
                 outputs = block(

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -911,6 +911,7 @@ class GPT2LMHeadModel(ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
@@ -934,6 +935,7 @@ class GPT2LMHeadModel(ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         hidden_states = transformer_outputs[0]
 
@@ -1077,6 +1079,7 @@ class GPT2DoubleHeadsModel(ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
         **kwargs,
     ):
         r"""
@@ -1133,6 +1136,7 @@ class GPT2DoubleHeadsModel(ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         hidden_states = transformer_outputs[0]
@@ -1236,6 +1240,7 @@ class GPT2ForSequenceClassification(ModelWithHeadsAdaptersMixin, GPT2PreTrainedM
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1257,6 +1262,7 @@ class GPT2ForSequenceClassification(ModelWithHeadsAdaptersMixin, GPT2PreTrainedM
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         hidden_states = transformer_outputs[0]
         logits = self.score(hidden_states)

--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -817,7 +817,6 @@ class MBartEncoder(InvertibleAdaptersMixin, BartEncoderDecoderAdaptersMixin, MBa
                         hidden_states,
                         attention_mask,
                         (head_mask[idx] if head_mask is not None else None),
-                        **kwargs,
                     )
                 else:
                     layer_outputs = encoder_layer(
@@ -1071,7 +1070,6 @@ class MBartDecoder(BartEncoderDecoderAdaptersMixin, MBartPreTrainedModel):
                     head_mask[idx] if head_mask is not None else None,
                     encoder_head_mask[idx] if encoder_head_mask is not None else None,
                     None,
-                    **kwargs,
                 )
             else:
 

--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -1394,6 +1394,7 @@ class MBartForConditionalGeneration(ModelWithHeadsAdaptersMixin, MBartPreTrained
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
@@ -1425,6 +1426,7 @@ class MBartForConditionalGeneration(ModelWithHeadsAdaptersMixin, MBartPreTrained
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         lm_logits = self.model.encoder.invertible_adapters_forward(outputs[0], rev=True)
         lm_logits = self.lm_head(lm_logits) + self.final_logits_bias
@@ -1524,6 +1526,7 @@ class MBartForSequenceClassification(ModelWithHeadsAdaptersMixin, MBartPreTraine
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1553,6 +1556,7 @@ class MBartForSequenceClassification(ModelWithHeadsAdaptersMixin, MBartPreTraine
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         hidden_states = outputs[0]  # last hidden state
 
@@ -1632,6 +1636,7 @@ class MBartForQuestionAnswering(ModelWithHeadsAdaptersMixin, MBartPreTrainedMode
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         start_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1661,6 +1666,7 @@ class MBartForQuestionAnswering(ModelWithHeadsAdaptersMixin, MBartPreTrainedMode
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         sequence_output = outputs[0]
@@ -1776,6 +1782,7 @@ class MBartForCausalLM(ModelWithHeadsAdaptersMixin, MBartPreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         Args:
@@ -1876,6 +1883,7 @@ class MBartForCausalLM(ModelWithHeadsAdaptersMixin, MBartPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         logits = self.lm_head(outputs[0])

--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -523,7 +523,6 @@ class RobertaEncoder(BertEncoderAdaptersMixin, nn.Module):
                     layer_head_mask,
                     encoder_hidden_states,
                     encoder_attention_mask,
-                    **kwargs,
                 )
             else:
                 layer_outputs = layer_module(

--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -989,6 +989,7 @@ class RobertaForCausalLM(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         encoder_hidden_states  (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, hidden_size)`, `optional`):
@@ -1050,6 +1051,7 @@ class RobertaForCausalLM(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         sequence_output = outputs[0]
@@ -1145,6 +1147,7 @@ class RobertaForMaskedLM(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
@@ -1168,6 +1171,7 @@ class RobertaForMaskedLM(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         sequence_output = outputs[0]
         prediction_scores = self.lm_head(
@@ -1258,6 +1262,7 @@ class RobertaForSequenceClassification(ModelWithHeadsAdaptersMixin, RobertaPreTr
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1277,6 +1282,7 @@ class RobertaForSequenceClassification(ModelWithHeadsAdaptersMixin, RobertaPreTr
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         sequence_output = outputs[0]
         logits = self.classifier(sequence_output)
@@ -1341,6 +1347,7 @@ class RobertaForMultipleChoice(ModelWithHeadsAdaptersMixin, RobertaPreTrainedMod
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
@@ -1371,6 +1378,7 @@ class RobertaForMultipleChoice(ModelWithHeadsAdaptersMixin, RobertaPreTrainedMod
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         pooled_output = outputs[1]
 
@@ -1435,6 +1443,7 @@ class RobertaForTokenClassification(ModelWithHeadsAdaptersMixin, RobertaPreTrain
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
@@ -1453,6 +1462,7 @@ class RobertaForTokenClassification(ModelWithHeadsAdaptersMixin, RobertaPreTrain
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
 
         sequence_output = outputs[0]
@@ -1545,6 +1555,7 @@ class RobertaForQuestionAnswering(ModelWithHeadsAdaptersMixin, RobertaPreTrained
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        adapter_names=None,
     ):
         r"""
         start_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):

--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -290,10 +290,10 @@ class RobertaSelfOutput(BertSelfOutputAdaptersMixin, nn.Module):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self._init_adapter_modules()
 
-    def forward(self, hidden_states, input_tensor):
+    def forward(self, hidden_states, input_tensor, **kwargs):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.dropout(hidden_states)
-        hidden_states = self.adapters_forward(hidden_states, input_tensor)
+        hidden_states = self.adapters_forward(hidden_states, input_tensor, **kwargs)
         return hidden_states
 
 
@@ -332,6 +332,7 @@ class RobertaAttention(nn.Module):
         encoder_attention_mask=None,
         past_key_value=None,
         output_attentions=False,
+        **kwargs
     ):
         self_outputs = self.self(
             hidden_states,
@@ -342,7 +343,7 @@ class RobertaAttention(nn.Module):
             past_key_value,
             output_attentions,
         )
-        attention_output = self.output(self_outputs[0], hidden_states)
+        attention_output = self.output(self_outputs[0], hidden_states, **kwargs)
         outputs = (attention_output,) + self_outputs[1:]  # add attentions if we output them
         return outputs
 
@@ -374,10 +375,10 @@ class RobertaOutput(BertOutputAdaptersMixin, nn.Module):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self._init_adapter_modules()
 
-    def forward(self, hidden_states, input_tensor):
+    def forward(self, hidden_states, input_tensor, **kwargs):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.dropout(hidden_states)
-        hidden_states = self.adapters_forward(hidden_states, input_tensor)
+        hidden_states = self.adapters_forward(hidden_states, input_tensor, **kwargs)
         return hidden_states
 
 
@@ -405,6 +406,7 @@ class RobertaLayer(BertLayerAdaptersMixin, nn.Module):
         encoder_attention_mask=None,
         past_key_value=None,
         output_attentions=False,
+        **kwargs
     ):
         # decoder uni-directional self-attention cached key/values tuple is at positions 1,2
         self_attn_past_key_value = past_key_value[:2] if past_key_value is not None else None
@@ -414,6 +416,7 @@ class RobertaLayer(BertLayerAdaptersMixin, nn.Module):
             head_mask,
             output_attentions=output_attentions,
             past_key_value=self_attn_past_key_value,
+            **kwargs,
         )
         attention_output = self_attention_outputs[0]
 
@@ -449,7 +452,7 @@ class RobertaLayer(BertLayerAdaptersMixin, nn.Module):
             present_key_value = present_key_value + cross_attn_present_key_value
 
         layer_output = apply_chunking_to_forward(
-            self.feed_forward_chunk, self.chunk_size_feed_forward, self.seq_len_dim, attention_output
+            self.feed_forward_chunk, self.chunk_size_feed_forward, self.seq_len_dim, attention_output, **kwargs
         )
         outputs = (layer_output,) + outputs
 
@@ -459,9 +462,9 @@ class RobertaLayer(BertLayerAdaptersMixin, nn.Module):
 
         return outputs
 
-    def feed_forward_chunk(self, attention_output):
+    def feed_forward_chunk(self, attention_output, **kwargs):
         intermediate_output = self.intermediate(attention_output)
-        layer_output = self.output(intermediate_output, attention_output)
+        layer_output = self.output(intermediate_output, attention_output, **kwargs)
         return layer_output
 
 
@@ -484,6 +487,7 @@ class RobertaEncoder(BertEncoderAdaptersMixin, nn.Module):
         output_attentions=False,
         output_hidden_states=False,
         return_dict=True,
+        **kwargs
     ):
         all_hidden_states = () if output_hidden_states else None
         all_self_attentions = () if output_attentions else None
@@ -519,6 +523,7 @@ class RobertaEncoder(BertEncoderAdaptersMixin, nn.Module):
                     layer_head_mask,
                     encoder_hidden_states,
                     encoder_attention_mask,
+                    **kwargs,
                 )
             else:
                 layer_outputs = layer_module(
@@ -529,6 +534,7 @@ class RobertaEncoder(BertEncoderAdaptersMixin, nn.Module):
                     encoder_attention_mask,
                     past_key_value,
                     output_attentions,
+                    **kwargs,
                 )
 
             hidden_states = layer_outputs[0]
@@ -750,6 +756,7 @@ class RobertaModel(BertModelAdaptersMixin, RobertaPreTrainedModel):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
+        **kwargs
     ):
         r"""
         encoder_hidden_states  (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, hidden_size)`, `optional`):
@@ -846,6 +853,7 @@ class RobertaModel(BertModelAdaptersMixin, RobertaPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            **kwargs,
         )
         sequence_output = encoder_outputs[0]
         pooled_output = self.pooler(sequence_output) if self.pooler is not None else None
@@ -894,8 +902,9 @@ class RobertaModelWithHeads(BertModelHeadsMixin, RobertaPreTrainedModel):
         inputs_embeds=None,
         output_attentions=None,
         output_hidden_states=None,
-        head=None,
         return_dict=None,
+        adapter_names=None,
+        head=None,
         **kwargs
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -920,6 +929,7 @@ class RobertaModelWithHeads(BertModelHeadsMixin, RobertaPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            adapter_names=adapter_names,
         )
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:

--- a/utils/check_adapters.py
+++ b/utils/check_adapters.py
@@ -1,6 +1,8 @@
+import inspect
+
 import transformers
 from check_repo import get_models
-from transformers import ModelAdaptersMixin
+from transformers import ModelAdaptersMixin, ModelWithHeadsAdaptersMixin
 
 
 MODELS_WITH_ADAPTERS = [
@@ -10,6 +12,7 @@ MODELS_WITH_ADAPTERS = [
     "distilbert",
     "bart",
     "mbart",
+    "gpt2",
 ]
 
 IGNORE_NOT_IMPLEMENTING_MIXIN = [
@@ -35,6 +38,13 @@ def check_models_implement_mixin():
                             and model_name not in IGNORE_NOT_IMPLEMENTING_MIXIN
                         ):
                             failures.append(f"{model_name} should implement ModelAdaptersMixin.")
+                        forward_fn_params = inspect.signature(model_class.forward).parameters
+                        # all classes implementing ModelWithHeadsAdaptersMixin should additionally provide adapter_names as parameter
+                        if (
+                            issubclass(model_class, ModelWithHeadsAdaptersMixin)
+                            and "adapter_names" not in forward_fn_params
+                        ):
+                            failures.append(f"{model_name}'s forward() method should provide adapter_names parameter.")
     if len(failures) > 0:
         raise Exception(f"There were {len(failures)} failures:\n" + "\n".join(failures))
 


### PR DESCRIPTION
Fixes #165.
Re-adds the `adapter_names` argument to all `*ModelWithHeads` & `*Model` classes with adapter support.