### PR TITLE
Add automatic conversion of static heads when loaded via XModelWithHeads

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,5 +47,5 @@ multi_line_output = 3
 use_parentheses = True
 
 [flake8]
-ignore = E203, E501, E741, W503, W605
+ignore = E203, E501, E731, E741, W503, W605
 max-line-length = 119

--- a/src/transformers/adapters/head_utils.py
+++ b/src/transformers/adapters/head_utils.py
@@ -199,19 +199,21 @@ def _regex_list_rename_func(k, rename_list):
     return k
 
 
-def get_head_config_and_rename_list(model_class_name, head_name, label2id):
-    if not label2id:
+def get_head_config_and_rename_list(model_class_name, head_name, label2id, num_labels=None):
+    if label2id is None:
         logger.warning(
             "No valid map of labels in label2id. Falling back to default (num_labels=2). This may cause errors during loading!"
         )
         label2id = {"LABEL_" + str(i): i for i in range(2)}
+    # num_labels is optional (e.g. for regression, when no map given)
+    num_labels = num_labels or len(label2id)
     data = STATIC_TO_FLEX_HEAD_MAP[model_class_name]
     # config
     config = data["config"]
     if config["head_type"] == "multiple_choice":
-        config["num_choices"] = len(label2id)
+        config["num_choices"] = num_labels
     else:
-        config["num_labels"] = len(label2id)
+        config["num_labels"] = num_labels
     config["label2id"] = label2id
     # rename
     rename_list = []

--- a/src/transformers/adapters/head_utils.py
+++ b/src/transformers/adapters/head_utils.py
@@ -1,4 +1,8 @@
+import logging
 import re
+
+
+logger = logging.getLogger(__name__)
 
 
 STATIC_TO_FLEX_HEAD_MAP = {
@@ -197,7 +201,10 @@ def _regex_list_rename_func(k, rename_list):
 
 def get_head_config_and_rename_list(model_class_name, head_name, label2id):
     if not label2id:
-        raise ValueError("Config must provide a valid map of labels in label2id.")
+        logger.warning(
+            "No valid map of labels in label2id. Falling back to default (num_labels=2). This may cause errors during loading!"
+        )
+        label2id = {"LABEL_" + str(i): i for i in range(2)}
     data = STATIC_TO_FLEX_HEAD_MAP[model_class_name]
     # config
     config = data["config"]

--- a/src/transformers/adapters/head_utils.py
+++ b/src/transformers/adapters/head_utils.py
@@ -1,0 +1,218 @@
+import re
+
+
+STATIC_TO_FLEX_HEAD_MAP = {
+    # BERT
+    "BertForSequenceClassification": {
+        "config": {
+            "head_type": "classification",
+            "layers": 1,
+            "activation_function": None,
+            "use_pooler": True,
+        },
+        "layers": ["classifier"],
+    },
+    "BertForMultipleChoice": {
+        "config": {
+            "head_type": "multiple_choice",
+            "layers": 1,
+            "activation_function": None,
+            "use_pooler": True,
+        },
+        "layers": ["classifier"],
+    },
+    "BertForTokenClassification": {
+        "config": {
+            "head_type": "tagging",
+            "layers": 1,
+            "activation_function": None,
+        },
+        "layers": ["classifier"],
+    },
+    "BertForQuestionAnswering": {
+        "config": {
+            "head_type": "question_answering",
+            "layers": 1,
+            "activation_function": None,
+        },
+        "layers": ["qa_outputs"],
+    },
+    # RoBERTa
+    "RobertaForSequenceClassification": {
+        "config": {
+            "head_type": "classification",
+            "layers": 2,
+            "activation_function": "tanh",
+            "use_pooler": False,
+        },
+        "layers": ["classifier.dense", "classifier.out_proj"],
+    },
+    "RobertaForMultipleChoice": {
+        "config": {
+            "head_type": "multiple_choice",
+            "layers": 1,
+            "activation_function": None,
+            "use_pooler": True,
+        },
+        "layers": ["classifier"],
+    },
+    "RobertaForTokenClassification": {
+        "config": {
+            "head_type": "tagging",
+            "layers": 1,
+            "activation_function": None,
+        },
+        "layers": ["classifier"],
+    },
+    "RobertaForQuestionAnswering": {
+        "config": {
+            "head_type": "question_answering",
+            "layers": 1,
+            "activation_function": None,
+        },
+        "layers": ["qa_outputs"],
+    },
+    # XLM-RoBERTa
+    "XLMRobertaForSequenceClassification": {
+        "config": {
+            "head_type": "classification",
+            "layers": 2,
+            "activation_function": "tanh",
+            "use_pooler": False,
+        },
+        "layers": ["classifier.dense", "classifier.out_proj"],
+    },
+    "XLMRobertaForMultipleChoice": {
+        "config": {
+            "head_type": "multiple_choice",
+            "layers": 1,
+            "activation_function": None,
+            "use_pooler": True,
+        },
+        "layers": ["classifier"],
+    },
+    "XLMRobertaForTokenClassification": {
+        "config": {
+            "head_type": "tagging",
+            "layers": 1,
+            "activation_function": None,
+        },
+        "layers": ["classifier"],
+    },
+    "XLMRobertaForQuestionAnswering": {
+        "config": {
+            "head_type": "question_answering",
+            "layers": 1,
+            "activation_function": None,
+        },
+        "layers": ["qa_outputs"],
+    },
+    # BART
+    "BartForSequenceClassification": {
+        "config": {
+            "head_type": "classification",
+            "layers": 2,
+            "activation_function": "tanh",
+        },
+        "layers": ["classification_head.dense", "classification_head.out_proj"],
+    },
+    "BartForQuestionAnswering": {
+        "config": {
+            "head_type": "question_answering",
+            "layers": 1,
+            "activation_function": None,
+        },
+        "layers": ["qa_outputs"],
+    },
+    # MBART
+    "MBartForSequenceClassification": {
+        "config": {
+            "head_type": "classification",
+            "layers": 2,
+            "activation_function": "tanh",
+        },
+        "layers": ["classification_head.dense", "classification_head.out_proj"],
+    },
+    "MBartForQuestionAnswering": {
+        "config": {
+            "head_type": "question_answering",
+            "layers": 1,
+            "activation_function": None,
+        },
+        "layers": ["qa_outputs"],
+    },
+    # DistilBERT
+    "DistilBertForSequenceClassification": {
+        "config": {
+            "head_type": "classification",
+            "layers": 2,
+            "activation_function": "relu",
+        },
+        "layers": ["pre_classifier", "classifier"],
+    },
+    "DistilBertForMultipleChoice": {
+        "config": {
+            "head_type": "multiple_choice",
+            "layers": 2,
+            "activation_function": "relu",
+        },
+        "layers": ["pre_classifier", "classifier"],
+    },
+    "DistilBertForTokenClassification": {
+        "config": {
+            "head_type": "tagging",
+            "layers": 1,
+            "activation_function": None,
+        },
+        "layers": ["classifier"],
+    },
+    "DistilBertForQuestionAnswering": {
+        "config": {
+            "head_type": "question_answering",
+            "layers": 1,
+            "activation_function": None,
+        },
+        "layers": ["qa_outputs"],
+    },
+    # GPT-2
+    "GPT2ForSequenceClassification": {
+        "config": {
+            "head_type": "classification",
+            "layers": 1,
+            "activation_function": None,
+            "bias": False,
+        },
+        "layers": ["score"],
+    },
+}
+
+
+def _regex_list_rename_func(k, rename_list):
+    for o, n in rename_list:
+        match = re.match(o, k)
+        if match:
+            return n.format(match.group(1))
+    return k
+
+
+def get_head_config_and_rename_list(model_class_name, head_name, label2id):
+    if not label2id:
+        raise ValueError("Config must provide a valid map of labels in label2id.")
+    data = STATIC_TO_FLEX_HEAD_MAP[model_class_name]
+    # config
+    config = data["config"]
+    if config["head_type"] == "multiple_choice":
+        config["num_choices"] = len(label2id)
+    else:
+        config["num_labels"] = len(label2id)
+    config["label2id"] = label2id
+    # rename
+    rename_list = []
+    i = 0
+    for name in data["layers"]:
+        escaped_name = re.escape(name)
+        rename_list.append((rf"{escaped_name}\.(\S+)", f"heads.{head_name}.{i+1}.{{0}}"))
+        i += 3 if config["activation_function"] else 2  # there's always a dropout layer in between
+    rename_func = lambda k, rename_list=rename_list: _regex_list_rename_func(k, rename_list)
+
+    return config, rename_func

--- a/src/transformers/adapters/heads.py
+++ b/src/transformers/adapters/heads.py
@@ -74,7 +74,7 @@ class ClassificationHead(PredictionHead):
             "num_labels": num_labels,
             "layers": layers,
             "activation_function": activation_function,
-            "label2id": {label: id_ for id_, label in id2label.items()} if id2label else None,
+            "label2id": {label: id_ for id_, label in id2label.items()} if id2label is not None else None,
             "use_pooler": use_pooler,
             "bias": bias,
         }
@@ -143,7 +143,7 @@ class MultiLabelClassificationHead(PredictionHead):
             "num_labels": num_labels,
             "layers": layers,
             "activation_function": activation_function,
-            "label2id": {label: id_ for id_, label in id2label.items()} if id2label else None,
+            "label2id": {label: id_ for id_, label in id2label.items()} if id2label is not None else None,
             "use_pooler": use_pooler,
             "bias": bias,
         }
@@ -208,7 +208,7 @@ class MultipleChoiceHead(PredictionHead):
             "num_choices": num_choices,
             "layers": layers,
             "activation_function": activation_function,
-            "label2id": {label: id_ for id_, label in id2label.items()} if id2label else None,
+            "label2id": {label: id_ for id_, label in id2label.items()} if id2label is not None else None,
             "use_pooler": use_pooler,
         }
         self.build(model)
@@ -257,7 +257,7 @@ class TaggingHead(PredictionHead):
             "num_labels": num_labels,
             "layers": layers,
             "activation_function": activation_function,
-            "label2id": {label: id_ for id_, label in id2label.items()} if id2label else None,
+            "label2id": {label: id_ for id_, label in id2label.items()} if id2label is not None else None,
         }
         self.build(model)
 
@@ -309,7 +309,7 @@ class QuestionAnsweringHead(PredictionHead):
             "num_labels": num_labels,
             "layers": layers,
             "activation_function": activation_function,
-            "label2id": {label: id_ for id_, label in id2label.items()} if id2label else None,
+            "label2id": {label: id_ for id_, label in id2label.items()} if id2label is not None else None,
         }
         self.build(model)
 
@@ -397,9 +397,9 @@ class ModelWithFlexibleHeadsAdaptersMixin(ModelWithHeadsAdaptersMixin):
         head_type = config.pop("head_type")
         # handle cases when id2label, label2id or both are available
         id2label = config.pop("id2label", None)
-        if not id2label:
+        if id2label is None:
             label2id = config.pop("label2id", None)
-            if label2id:
+            if label2id is not None:
                 id2label = {id_: label for label, id_ in label2id.items()}
         else:
             # don't pass label2id to head_class

--- a/src/transformers/adapters/loading.py
+++ b/src/transformers/adapters/loading.py
@@ -604,6 +604,10 @@ class PredictionHeadLoader(WeightsLoader):
             model_class=self.model.__class__.__name__,
             save_id2label=True,
         )
+        # Add number of labels to config if present
+        if head_config is None and hasattr(self.model.config, "num_labels"):
+            config_dict["num_labels"] = self.model.config.num_labels
+
         self.weights_helper.save_weights_config(save_directory, config_dict)
 
         # Save head weights
@@ -665,7 +669,10 @@ class PredictionHeadLoader(WeightsLoader):
                             "Could not identify a name for the prediction head to be loaded. Please specify 'load_as'."
                         )
                     head_config, conversion_rename_func = get_head_config_and_rename_list(
-                        config["model_class"], head_name, custom_label2id or config.get("label2id")
+                        config["model_class"],
+                        head_name,
+                        custom_label2id or config.get("label2id"),
+                        num_labels=config.get("num_labels"),
                     )
                 else:
                     raise ValueError(

--- a/src/transformers/adapters/loading.py
+++ b/src/transformers/adapters/loading.py
@@ -676,8 +676,9 @@ class PredictionHeadLoader(WeightsLoader):
 
                 # make sure the label2id map is correct
                 custom_label2id = custom_label2id or head_config.get("label2id", None)
-                head_config["id2label"] = {int(id_): label for label, id_ in custom_label2id.items()}
-                head_config["label2id"] = {label: int(id_) for label, id_ in custom_label2id.items()}
+                if custom_label2id:
+                    head_config["id2label"] = {int(id_): label for label, id_ in custom_label2id.items()}
+                    head_config["label2id"] = {label: int(id_) for label, id_ in custom_label2id.items()}
 
                 self.model.add_prediction_head_from_config(head_name, head_config, overwrite_ok=True)
             # model with static head
@@ -685,8 +686,9 @@ class PredictionHeadLoader(WeightsLoader):
                 if self.convert_to_flex_head:
                     raise ValueError("Cannot set convert_flex_head on model class with static head.")
                 custom_label2id = custom_label2id or config.get("label2id", None)
-                self.model.config.id2label = {int(id_): label for label, id_ in custom_label2id.items()}
-                self.model.config.label2id = {label: int(id_) for label, id_ in custom_label2id.items()}
+                if custom_label2id:
+                    self.model.config.id2label = {int(id_): label for label, id_ in custom_label2id.items()}
+                    self.model.config.label2id = {label: int(id_) for label, id_ in custom_label2id.items()}
 
         # Load head weights
         filter_func = self.filter_func(head_name)

--- a/src/transformers/adapters/loading.py
+++ b/src/transformers/adapters/loading.py
@@ -558,7 +558,7 @@ class PredictionHeadLoader(WeightsLoader):
         else:
             return lambda x: not x.startswith(self.model.base_model_prefix)
 
-    def rename_func(self, old_name, new_name, rename_list=None):
+    def rename_func(self, old_name, new_name):
         return lambda k: k.replace("heads.{}".format(old_name), "heads.{}".format(new_name))
 
     def save(self, save_directory: str, name: str = None):

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -319,6 +319,7 @@ class ModelAdaptersMixin(ABC):
         load_as: str = None,
         custom_weights_loaders: Optional[List[WeightsLoader]] = None,
         leave_out: Optional[List[int]] = None,
+        id2label=None,
         **kwargs
     ) -> str:
         """
@@ -354,7 +355,7 @@ class ModelAdaptersMixin(ABC):
                     load_as=load_as,
                     loading_info=kwargs.get("loading_info", None),
                     main_load_name=load_name,
-                    id2label=kwargs.get("id2label", None),
+                    id2label=id2label,
                 )
         return load_name
 
@@ -535,6 +536,7 @@ class ModelWithHeadsAdaptersMixin(ModelAdaptersMixin):
         with_head: bool = True,
         custom_weights_loaders: Optional[List[WeightsLoader]] = None,
         leave_out: Optional[List[int]] = None,
+        id2label=None,
         **kwargs
     ) -> str:
         if with_head:
@@ -547,6 +549,10 @@ class ModelWithHeadsAdaptersMixin(ModelAdaptersMixin):
                     convert_to_flex_head=self._convert_to_flex_head,
                 )
             )
+        # Support passing a num_labels for compatibility reasons. Convert to label map here.
+        num_labels = kwargs.pop("num_labels", None)
+        if num_labels is not None:
+            id2label = {i: "LABEL_" + str(i) for i in range(num_labels)}
         return super().load_adapter(
             adapter_name_or_path,
             config=config,
@@ -555,6 +561,7 @@ class ModelWithHeadsAdaptersMixin(ModelAdaptersMixin):
             load_as=load_as,
             custom_weights_loaders=custom_weights_loaders,
             leave_out=leave_out,
+            id2label=id2label,
             **kwargs,
         )
 

--- a/src/transformers/adapters/models/bert.py
+++ b/src/transformers/adapters/models/bert.py
@@ -167,6 +167,7 @@ class BertModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
         overwrite_ok=False,
         multilabel=False,
         id2label=None,
+        use_pooler=False,
     ):
         """
         Adds a sequence classification head on top of the model.
@@ -181,13 +182,22 @@ class BertModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
         """
 
         if multilabel:
-            head = MultiLabelClassificationHead(self, head_name, num_labels, layers, activation_function, id2label)
+            head = MultiLabelClassificationHead(
+                self, head_name, num_labels, layers, activation_function, id2label, use_pooler
+            )
         else:
-            head = ClassificationHead(self, head_name, num_labels, layers, activation_function, id2label)
+            head = ClassificationHead(self, head_name, num_labels, layers, activation_function, id2label, use_pooler)
         self.add_prediction_head(head, overwrite_ok)
 
     def add_multiple_choice_head(
-        self, head_name, num_choices=2, layers=2, activation_function="tanh", overwrite_ok=False, id2label=None
+        self,
+        head_name,
+        num_choices=2,
+        layers=2,
+        activation_function="tanh",
+        overwrite_ok=False,
+        id2label=None,
+        use_pooler=False,
     ):
         """
         Adds a multiple choice head on top of the model.
@@ -199,7 +209,7 @@ class BertModelHeadsMixin(ModelWithFlexibleHeadsAdaptersMixin):
             activation_function (str, optional): Activation function. Defaults to 'tanh'.
             overwrite_ok (bool, optional): Force overwrite if a head with the same name exists. Defaults to False.
         """
-        head = MultipleChoiceHead(self, head_name, num_choices, layers, activation_function, id2label)
+        head = MultipleChoiceHead(self, head_name, num_choices, layers, activation_function, id2label, use_pooler)
         self.add_prediction_head(head, overwrite_ok)
 
     def add_tagging_head(

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -1086,10 +1086,16 @@ class BertModelWithHeads(BertModelHeadsMixin, BertPreTrainedModel):
             head_inputs = (outputs[0],) + outputs[2:]
         else:
             head_inputs = outputs
+        pooled_output = outputs[1]
 
         if head or self.active_head:
             head_outputs = self.forward_head(
-                head_inputs, head_name=head, attention_mask=attention_mask, return_dict=return_dict, **kwargs
+                head_inputs,
+                head_name=head,
+                attention_mask=attention_mask,
+                return_dict=return_dict,
+                pooled_output=pooled_output,
+                **kwargs,
             )
             return head_outputs
         else:

--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -935,10 +935,16 @@ class RobertaModelWithHeads(BertModelHeadsMixin, RobertaPreTrainedModel):
             head_inputs = (outputs[0],) + outputs[2:]
         else:
             head_inputs = outputs
+        pooled_output = outputs[1]
 
         if head or self.active_head:
             head_outputs = self.forward_head(
-                head_inputs, head_name=head, attention_mask=attention_mask, return_dict=return_dict, **kwargs
+                head_inputs,
+                head_name=head,
+                attention_mask=attention_mask,
+                return_dict=return_dict,
+                pooled_output=pooled_output,
+                **kwargs,
             )
             return head_outputs
         else:


### PR DESCRIPTION
Changes in detail:
- Enable conversion of static heads to flex head model heads.
- Add use_pooler argument classification & m.-choice heads.
- Allow passing of id2label to prediciton head loading.
- Save "num_labels" into static head config and use it for conversion to flex head

Current limitations:
`id2label`/`label2id` must be either present in the head config (often not the case, e.g. [here](https://adapterhub.ml/adapters/ukp/bert-base-uncased_lingaccept_cola_houlsby/)) or explicitly provided to `load_adapter()`/`load_head()`. Alternatively, `num_labels` can be passed to load_adapter(). Fix must be provided on the Hub side.

Example notebook: https://colab.research.google.com/drive/1JYAPKlPtJwCddc-Jra9WG9Cw5RVjFkhR?usp=sharing