### PR TITLE
Add delete_adapter(), delete_adapter_fusion() and delete_head() methods

### DIFF
--- a/adapter_docs/prediction_heads.md
+++ b/adapter_docs/prediction_heads.md
@@ -55,6 +55,12 @@ model.save_head("/path/to/dir", "mrpc")
 model.load_head("/path/to/dir")
 ```
 
+Lastly, it's also possible to delete an added head again:
+
+```python
+model.delete_head("mrpc")
+```
+
 ## HuggingFace heads
 
 The `transformers` library provides strongly typed model classes with heads for various different tasks (e.g. `RobertaForSequenceClassification`, `AutoModelForMultipleChoice` ...).

--- a/adapter_docs/quickstart.md
+++ b/adapter_docs/quickstart.md
@@ -3,8 +3,8 @@
 ## Introduction
 
 Currently, *adapter-transformers* adds adapter components to the PyTorch implementations of all transformer models listed in the *Supported Models* section.
-For working with adapters, a couple of methods for creation (e.g. `add_adapter()`), loading (e.g. `load_adapter()`) and
-storing (e.g. `save_adapter()`) are added to the model classes. In the following, we will briefly go through some examples.
+For working with adapters, a couple of methods for creation (`add_adapter()`), loading (`load_adapter()`), 
+storing (`save_adapter()`) and deletion (`delete_adapter()`) are added to the model classes. In the following, we will briefly go through some examples.
 
 ```eval_rst
 .. note::
@@ -79,6 +79,15 @@ model.load_adapter('./path/to/adapter/directory/')
 ```
 
 Similar to how the weights of the full model are saved, the `save_adapter()` will create a file for saving the adapter weights and a file for saving the adapter configuration in the specified directory.
+
+Finally, if we have finished working with adapters, we can restore the base Transformer in its original form by deactivating and deleting the adapter:
+
+```python
+# deactivate all adapters
+model.set_active_adapters(None)
+# delete the added adapter
+model.delete_adapter('sst-2')
+```
 
 ## Quick Tour: Adapter training
 

--- a/src/transformers/adapters/configuration.py
+++ b/src/transformers/adapters/configuration.py
@@ -2,7 +2,7 @@ import copy
 import logging
 from collections.abc import Collection, Mapping
 from dataclasses import FrozenInstanceError, asdict, dataclass, field, is_dataclass, replace
-from typing import List, Optional, Sequence, Union
+from typing import List, Optional, Union
 
 from .composition import AdapterCompositionBlock
 from .utils import get_adapter_config_hash, resolve_adapter_config
@@ -195,7 +195,7 @@ class ModelAdaptersConfig(Collection):
         adapters_list = dict(
             map(lambda t: (t[0], t[1][1] or t[1][0] if isinstance(t[1], tuple) else t[1]), adapters_list.items())
         )
-        self.adapters: Sequence[str] = adapters_list
+        self.adapters: Mapping[str] = adapters_list
         self.config_map = kwargs.pop("config_map", {})
         # TODO-V2 Save this with config?
         self.active_setup: Optional[AdapterCompositionBlock] = None

--- a/src/transformers/adapters/heads.py
+++ b/src/transformers/adapters/heads.py
@@ -520,6 +520,21 @@ class ModelWithFlexibleHeadsAdaptersMixin(ModelWithHeadsAdaptersMixin):
                 f"Model already contains a head with name '{head.name}'. Use overwrite_ok=True to force overwrite."
             )
 
+    def delete_head(self, head_name: str):
+        """
+        Deletes the prediction head with the specified name from the model.
+
+        Args:
+            head_name (str): The name of the prediction to delete.
+        """
+        if head_name not in self.config.prediction_heads:
+            logger.info("No prediction head '%s' found for deletion. Skipping.", head_name)
+            return
+        del self.config.prediction_heads[head_name]
+        del self.heads[head_name]
+        if self.active_head == head_name:
+            self.active_head = None
+
     def forward_head(
         self, all_outputs, head_name=None, cls_output=None, attention_mask=None, return_dict=False, **kwargs
     ):

--- a/src/transformers/adapters/layer.py
+++ b/src/transformers/adapters/layer.py
@@ -67,6 +67,10 @@ class AdapterLayerBaseMixin(ABC):
             adapter.train(self.training)  # make sure training mode is consistent
             self.adapters[adapter_name] = adapter
 
+    def delete_adapter(self, adapter_name: str):
+        if adapter_name in self.adapters:
+            del self.adapters[adapter_name]
+
     def add_fusion_layer(self, adapter_names: Union[List, str]):
         """See BertModel.add_fusion_layer"""
         adapter_names = adapter_names if isinstance(adapter_names, list) else adapter_names.split(",")
@@ -74,6 +78,11 @@ class AdapterLayerBaseMixin(ABC):
             fusion = BertFusion(self.config)
             fusion.train(self.training)  # make sure training mode is consistent
             self.adapter_fusion_layer[",".join(adapter_names)] = fusion
+
+    def delete_fusion_layer(self, adapter_names: Union[List, str]):
+        adapter_names = adapter_names if isinstance(adapter_names, str) else ",".join(adapter_names)
+        if adapter_names in self.adapter_fusion_layer:
+            del self.adapter_fusion_layer[adapter_names]
 
     def enable_adapters(self, adapter_setup: AdapterCompositionBlock, unfreeze_adapters: bool, unfreeze_fusion: bool):
         """

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -5,7 +5,7 @@ from typing import List, Mapping, Optional, Union
 
 from torch import nn
 
-from .composition import AdapterCompositionBlock, Fuse, parse_composition
+from .composition import AdapterCompositionBlock, Fuse, Stack, parse_composition
 from .configuration import (
     ADAPTERFUSION_CONFIG_MAP,
     DEFAULT_ADAPTERFUSION_CONFIG,
@@ -280,6 +280,9 @@ class ModelAdaptersMixin(ABC):
             return
         del self.config.adapters.adapters[adapter_name]
         self.base_model._delete_adapter(adapter_name)
+        # Reset active adapters if this was the only active adapter
+        if self.active_adapters == Stack(adapter_name):
+            self.active_adapters = None
 
     def delete_adapter_fusion(self, adapter_names: Union[Fuse, list]):
         """

--- a/src/transformers/adapters/models/bart.py
+++ b/src/transformers/adapters/models/bart.py
@@ -91,6 +91,14 @@ class BartEncoderLayerAdaptersMixin:
         self.attention_adapters.add_adapter(adapter_name, layer_idx)
         self.output_adapters.add_adapter(adapter_name, layer_idx)
 
+    def delete_adapter(self, adapter_name):
+        self.attention_adapters.delete_adapter(adapter_name)
+        self.output_adapters.delete_adapter(adapter_name)
+
+    def delete_fusion_layer(self, adapter_names):
+        self.attention_adapters.delete_fusion_layer(adapter_names)
+        self.output_adapters.delete_fusion_layer(adapter_names)
+
     def enable_adapters(self, adapter_names: list, unfreeze_adapters: bool, unfreeze_attention: bool):
         self.attention_adapters.enable_adapters(adapter_names, unfreeze_adapters, unfreeze_attention)
         self.output_adapters.enable_adapters(adapter_names, unfreeze_adapters, unfreeze_attention)
@@ -112,6 +120,14 @@ class BartDecoderLayerAdaptersMixin(BartEncoderLayerAdaptersMixin):
         super().add_adapter(adapter_name, layer_idx)
         self.cross_attention_adapters.add_adapter(adapter_name, layer_idx)
 
+    def delete_adapter(self, adapter_name):
+        super().delete_adapter(adapter_name)
+        self.cross_attention_adapters.delete_adapter(adapter_name)
+
+    def delete_fusion_layer(self, adapter_names):
+        super().delete_fusion_layer(adapter_names)
+        self.cross_attention_adapters.delete_fusion_layer(adapter_names)
+
     def enable_adapters(self, adapter_names: list, unfreeze_adapters: bool, unfreeze_attention: bool):
         super().enable_adapters(adapter_names, unfreeze_adapters, unfreeze_attention)
         self.cross_attention_adapters.enable_adapters(adapter_names, unfreeze_adapters, unfreeze_attention)
@@ -130,6 +146,14 @@ class BartEncoderDecoderAdaptersMixin:
         for i, layer in enumerate(self.layers, start=layer_idx_offset):
             if i not in leave_out:
                 layer.add_adapter(adapter_name, i)
+
+    def delete_adapter(self, adapter_name: str):
+        for layer in self.layers:
+            layer.delete_adapter(adapter_name)
+
+    def delete_fusion_layer(self, adapter_names):
+        for layer in self.layers:
+            layer.delete_fusion_layer(adapter_names)
 
     def enable_adapters(
         self, adapter_setup: AdapterCompositionBlock, unfreeze_adapters: bool, unfreeze_attention: bool
@@ -196,6 +220,17 @@ class BartModelAdaptersMixin(ModelAdaptersMixin):
         if hasattr(self, "encoder"):
             self.encoder.add_fusion_layer(adapter_names)
         self.decoder.add_fusion_layer(adapter_names)
+
+    def _delete_adapter(self, adapter_name: str):
+        if hasattr(self, "encoder"):
+            self.encoder.delete_adapter(adapter_name)
+            self.encoder.delete_invertible_adapter(adapter_name)
+        self.decoder.delete_adapter(adapter_name)
+
+    def _delete_fusion_layer(self, adapter_names):
+        if hasattr(self, "encoder"):
+            self.encoder.delete_fusion_layer(adapter_names)
+        self.decoder.delete_fusion_layer(adapter_names)
 
     def get_fusion_regularization_loss(self):
         reg_loss = 0.0

--- a/src/transformers/adapters/models/bert.py
+++ b/src/transformers/adapters/models/bert.py
@@ -46,6 +46,14 @@ class BertLayerAdaptersMixin:
         self.attention.output.add_adapter(adapter_name, layer_idx)
         self.output.add_adapter(adapter_name, layer_idx)
 
+    def delete_adapter(self, adapter_name):
+        self.attention.output.delete_adapter(adapter_name)
+        self.output.delete_adapter(adapter_name)
+
+    def delete_fusion_layer(self, adapter_names):
+        self.attention.output.delete_fusion_layer(adapter_names)
+        self.output.delete_fusion_layer(adapter_names)
+
     def enable_adapters(
         self, adapter_setup: AdapterCompositionBlock, unfreeze_adapters: bool, unfreeze_attention: bool
     ):
@@ -66,6 +74,14 @@ class BertEncoderAdaptersMixin:
         for i, layer in enumerate(self.layer):
             if i not in leave_out:
                 layer.add_adapter(adapter_name, i)
+
+    def delete_adapter(self, adapter_name: str):
+        for layer in self.layer:
+            layer.delete_adapter(adapter_name)
+
+    def delete_fusion_layer(self, adapter_names):
+        for layer in self.layer:
+            layer.delete_fusion_layer(adapter_names)
 
     def enable_adapters(
         self, adapter_setup: AdapterCompositionBlock, unfreeze_adapters: bool, unfreeze_attention: bool
@@ -113,6 +129,13 @@ class BertModelAdaptersMixin(InvertibleAdaptersMixin, ModelAdaptersMixin):
 
     def _add_fusion_layer(self, adapter_names):
         self.encoder.add_fusion_layer(adapter_names)
+
+    def _delete_adapter(self, adapter_name: str):
+        self.encoder.delete_adapter(adapter_name)
+        self.delete_invertible_adapter(adapter_name)
+
+    def _delete_fusion_layer(self, adapter_names):
+        self.encoder.delete_fusion_layer(adapter_names)
 
     def get_fusion_regularization_loss(self):
         reg_loss = 0.0

--- a/src/transformers/adapters/models/distilbert.py
+++ b/src/transformers/adapters/models/distilbert.py
@@ -53,6 +53,14 @@ class DistilBertTransfomerBlockAdaptersMixin:
         self.attention_adapters.add_adapter(adapter_name, layer_idx)
         self.output_adapters.add_adapter(adapter_name, layer_idx)
 
+    def delete_adapter(self, adapter_name):
+        self.attention_adapters.delete_adapter(adapter_name)
+        self.output_adapters.delete_adapter(adapter_name)
+
+    def delete_fusion_layer(self, adapter_names):
+        self.attention_adapters.delete_fusion_layer(adapter_names)
+        self.output_adapters.delete_fusion_layer(adapter_names)
+
     def enable_adapters(self, adapter_names: list, unfreeze_adapters: bool, unfreeze_attention: bool):
         self.attention_adapters.enable_adapters(adapter_names, unfreeze_adapters, unfreeze_attention)
         self.output_adapters.enable_adapters(adapter_names, unfreeze_adapters, unfreeze_attention)
@@ -95,6 +103,13 @@ class DistilBertModelAdaptersMixin(InvertibleAdaptersMixin, ModelAdaptersMixin):
 
     def _add_fusion_layer(self, adapter_names):
         self.transformer.add_fusion_layer(adapter_names)
+
+    def _delete_adapter(self, adapter_name: str):
+        self.transformer.delete_adapter(adapter_name)
+        self.delete_invertible_adapter(adapter_name)
+
+    def _delete_fusion_layer(self, adapter_names):
+        self.transformer.delete_fusion_layer(adapter_names)
 
     def get_fusion_regularization_loss(self):
         reg_loss = 0.0

--- a/src/transformers/adapters/models/gpt2.py
+++ b/src/transformers/adapters/models/gpt2.py
@@ -59,6 +59,14 @@ class GPT2DecoderBlockAdaptersMixin(BertEncoderAdaptersMixin):
         self.attention_adapters.add_adapter(adapter_name, layer_idx)
         self.output_adapters.add_adapter(adapter_name, layer_idx)
 
+    def delete_adapter(self, adapter_name):
+        self.attention_adapters.delete_adapter(adapter_name)
+        self.output_adapters.delete_adapter(adapter_name)
+
+    def delete_fusion_layer(self, adapter_names):
+        self.attention_adapters.delete_fusion_layer(adapter_names)
+        self.output_adapters.delete_fusion_layer(adapter_names)
+
     def enable_adapters(self, adapter_names: list, unfreeze_adapters: bool, unfreeze_attention: bool):
         self.attention_adapters.enable_adapters(adapter_names, unfreeze_adapters, unfreeze_attention)
         self.output_adapters.enable_adapters(adapter_names, unfreeze_adapters, unfreeze_attention)
@@ -78,21 +86,6 @@ class GPT2ModelAdapterMixin(InvertibleAdaptersMixin, ModelAdaptersMixin):
         if hasattr(self.config, "fusion_models"):
             for fusion_adapter_names in self.config.fusion_models:
                 self.add_fusion_layer(fusion_adapter_names)
-
-    def add_adapter(self, adapter_name: str, config=None):
-        """
-        Adds a new adapter module of the specified type to the model.
-
-        Args:
-            adapter_name (str): The name of the adapter module to be added.
-            config (str or dict or AdapterConfig, optional): The adapter configuration, can be either:
-
-                - the string identifier of a pre-defined configuration dictionary
-                - a configuration dictionary specifying the full config
-                - if not given, the default configuration for this adapter type will be used
-        """
-        self.config.adapters.add(adapter_name, config=config)
-        self._add_adapter(adapter_name)
 
     def _add_adapter(self, adapter_name: str):
         adapter_config = self.config.adapters.get(adapter_name)
@@ -136,6 +129,15 @@ class GPT2ModelAdapterMixin(InvertibleAdaptersMixin, ModelAdaptersMixin):
     def _add_fusion_layer(self, adapter_names):
         for layer in self.base_model.h:
             layer.add_fusion_layer(adapter_names)
+
+    def _delete_adapter(self, adapter_name: str):
+        for layer in self.base_model.h:
+            layer.delete_adapter(adapter_name)
+        self.delete_invertible_adapter(adapter_name)
+
+    def _delete_fusion_layer(self, adapter_names):
+        for layer in self.base_model.h:
+            layer.delete_fusion_layer(adapter_names)
 
     def get_fusion_regularization_loss(self):
         reg_loss = 0.0

--- a/tests/test_adapter_common.py
+++ b/tests/test_adapter_common.py
@@ -72,6 +72,23 @@ class AdapterModelTestMixin:
                 self.assertEqual(len(adapter_output), len(base_output))
                 self.assertFalse(torch.equal(adapter_output[0], base_output[0]))
 
+    def test_delete_adapter(self):
+        model = AutoModel.from_config(self.config())
+        model.eval()
+
+        name = "test_adapter"
+        model.add_adapter(name, config="houlsby")
+        model.set_active_adapters([name])
+
+        # adapter is correctly added to config
+        self.assertTrue(name in model.config.adapters)
+        self.assertGreater(len(model.get_adapter(name)), 0)
+
+        # remove the adapter again
+        model.delete_adapter(name)
+        self.assertFalse(name in model.config.adapters)
+        self.assertEqual(len(model.get_adapter(name)), 0)
+
     def test_add_adapter_with_invertible(self):
         model = AutoModel.from_config(self.config())
         model.eval()

--- a/tests/test_adapter_fusion_common.py
+++ b/tests/test_adapter_fusion_common.py
@@ -57,6 +57,23 @@ class AdapterFusionModelTestMixin:
         # failing fusion
         self.assertRaises(ValueError, lambda: model.add_fusion(["a", "c"]))
 
+    def test_delete_adapter_fusion(self):
+        model = AutoModel.from_config(self.config())
+        model.eval()
+
+        name1 = "test_adapter_1"
+        name2 = "test_adapter_2"
+        model.add_adapter(name1, config="houlsby")
+        model.add_adapter(name2, config="houlsby")
+        self.assertTrue(name1 in model.config.adapters)
+        self.assertTrue(name2 in model.config.adapters)
+
+        model.add_fusion([name1, name2])
+        self.assertTrue(",".join([name1, name2]) in model.config.adapter_fusion_models)
+
+        model.delete_adapter_fusion([name1, name2])
+        self.assertFalse(",".join([name1, name2]) in model.config.adapter_fusion_models)
+
     def test_load_adapter_fusion(self):
         for adater_fusion_config_name, adapter_fusion_config in ADAPTERFUSION_CONFIG_MAP.items():
             model1 = AutoModel.from_config(self.config())

--- a/tests/test_adapter_heads.py
+++ b/tests/test_adapter_heads.py
@@ -91,6 +91,21 @@ class PredictionHeadModelTestMixin:
         label_dict["end_positions"] = torch.zeros(self.batch_size, dtype=torch.long, device=torch_device)
         self.run_prediction_head_test(model1, model2, "dummy", output_shape=(1, 128), label_dict=label_dict)
 
+    def test_delete_head(self):
+        model = AutoModelWithHeads.from_config(self.config())
+        model.eval()
+
+        name = "test_head"
+        model.add_classification_head(name)
+        self.assertTrue(name in model.heads)
+        self.assertTrue(name in model.config.prediction_heads)
+        self.assertEqual(name, model.active_head)
+
+        model.delete_head(name)
+        self.assertFalse(name in model.heads)
+        self.assertFalse(name in model.config.prediction_heads)
+        self.assertNotEqual(name, model.active_head)
+
     def test_adapter_with_head(self):
         model1, model2 = create_twin_models(AutoModelWithHeads, self.config)
 


### PR DESCRIPTION
- Adds methods for removing adapters (`delete_adapter()`), AdapterFusion (`delete_adapter_fusion()`) and prediction heads (`delete_head()`)
- Adds option `overwrite_ok` to `add_adapter()` to overwrite an existing adapter with the same name.

Resolves #179.