### PR TITLE
Add method to push adapters to HF Model Hub

### DIFF
--- a/adapter_docs/classes/model_mixins.rst
+++ b/adapter_docs/classes/model_mixins.rst
@@ -33,3 +33,9 @@ ModelWithFlexibleHeadsAdaptersMixin
 
 .. autoclass:: transformers.ModelWithFlexibleHeadsAdaptersMixin
     :members:
+
+PushAdapterToHubMixin
+----------------------
+
+.. autoclass:: transformers.adapters.hub_mixin.PushAdapterToHubMixin
+    :members:

--- a/adapter_docs/conf.py
+++ b/adapter_docs/conf.py
@@ -15,6 +15,7 @@
 # sys.path.insert(0, os.path.abspath('.'))
 from recommonmark.transform import AutoStructify
 
+
 # -- Project information -----------------------------------------------------
 
 project = 'adapter-transformers'
@@ -30,7 +31,8 @@ author = 'Adapter-Hub Team'
 extensions = [
     'recommonmark',
     'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'sphinx_copybutton',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/adapter_docs/contributing.md
+++ b/adapter_docs/contributing.md
@@ -1,4 +1,9 @@
-# Contributing to Adapter Hub
+# Contributing to AdapterHub
+
+```eval_rst
+.. note::
+    This document describes how to contribute adapters via the AdapterHub `Hub repository <https://github.com/adapter-hub/hub>`_. See `Integration with HuggingFace's Model Hub <huggingface_hub.html>`_ for uploading adapters via the HuggingFace Model Hub.
+```
 
 You can easily add your own pre-trained adapter modules or architectures to Adapter Hub via our [Hub GitHub repo](https://github.com/adapter-hub/hub). Please make sure to follow the steps below corresponding to the type of contribution you would like to make.
 
@@ -9,16 +14,15 @@ Before making any kind of contribution to _Adapter-Hub_, you will first need to 
 1. Fork [the Hub repository](https://github.com/adapter-hub/hub) by clicking the 'Fork' button on the repository's page. This creates a clone of the repository under your GitHub user.
 
 2. Clone your fork to your local file system:
-```bash
-git clone git@github.com:<YOUR_GITHUB_USER>/Hub.git
-cd Hub
-```
+    ```bash
+    git clone git@github.com:<YOUR_GITHUB_USER>/Hub.git
+    cd Hub
+    ```
 
 3. Set up the Python environment. This includes the `adapter-hub-cli` which helps in preparing your adapters for the Hub.
-
-```bash
-pip install -U ./scripts/.
-```
+    ```bash
+    pip install -U ./scripts/.
+    ```
 
 As you're fully set up now, you can proceed on the specific steps if your contribution:
 

--- a/adapter_docs/huggingface_hub.md
+++ b/adapter_docs/huggingface_hub.md
@@ -18,7 +18,7 @@ model = AutoModelWithHeads.from_pretrained("roberta-base")
 adapter_name = model.load_adapter("AdapterHub/roberta-base-pf-sick", source="hf")
 model.active_adapters = adapter_name
 ```
-Note that `source=hf` is the only change from loading an adapter from AdapterHub.
+Note that `source="hf"` is the only change from loading an adapter from AdapterHub.
 
 ## Uploading to the Hub
 

--- a/adapter_docs/huggingface_hub.md
+++ b/adapter_docs/huggingface_hub.md
@@ -1,0 +1,66 @@
+# Integration with HuggingFace's Model Hub
+
+Starting with v2.1 of `adapter-transformers`, you can download adapters from and upload them to [HuggingFace's Model Hub](https://huggingface.co/models).
+This document describes how to interact with the Model Hub when working with adapters.
+
+## Downloading from the Hub
+
+The HuggingFace Model Hub already provides a few pre-trained adapters available for download.
+To search for available adapters, use the _Adapter Transformers_ library filter on the Model Hub website or use this link: [https://huggingface.co/models?filter=adapter-transformers](https://huggingface.co/models?filter=adapter-transformers).
+Alternatively, all adapters on the HuggingFace Model Hub are also listed on [https://adapterhub.ml/explore](https://adapterhub.ml/explore) together with all adapters directly uploaded to AdapterHub.
+
+After you have found an adapter you would like to use, loading it into a Transformer model is very similar to [loading adapters from AdapterHub](loading.md).
+For example, for loading and activating the adapter [`AdapterHub/roberta-base-pf-sick`](https://huggingface.co/AdapterHub/roberta-base-pf-sick), write:
+```python
+from transformers import AutoModelWithHeads
+
+model = AutoModelWithHeads.from_pretrained("roberta-base")
+adapter_name = model.load_adapter("AdapterHub/roberta-base-pf-sick", source="hf")
+model.active_adapters = adapter_name
+```
+Note that `source=hf` is the only change from loading an adapter from AdapterHub.
+
+## Uploading to the Hub
+
+HuggingFace's Model Hub provides a convenient way for everyone to upload their pre-trained models and share them with the world.
+Of course, this is also possible with adapters now!
+In the following, we'll go through the fastest way of uploading an adapter directly via Python in the `adapter-transformers` library.
+For more options and information, e.g. for managing models via the CLI and Git, refer to [HugginFace's documentation](https://huggingface.co/transformers/model_sharing.html).
+
+1. **Prepare access credentials**: Before being able to push to the HuggingFace Model Hub for the first time, we have to store our access token in the cache.
+    This can be done via the `transformers-cli` by running:
+    ```
+    transformers-cli login
+    ```
+
+2. **Push an adapter**: Next, we can proceed to upload our first adapter.
+    Let's say we have a standard pre-trained Transformers model with an existing adapter named `awesome_adapter` (e.g. added via `model.add_adapter("awesome_adapter")` and [trained](training.md) afterwards).
+    We can now push this adapter to the Model Hub using `model.push_adapter_to_hub()` like this:
+    ```python
+    model.push_adapter_to_hub(
+        "my-awesome-adapter",
+        "awesome_adapter",
+        adapterhub_tag="sentiment/imdb",
+        datasets_tag="imdb"
+    )
+    ```
+    This will create a repository `my-awesome-adapter` under your username, generate a default adapter card as `README.md` and upload the adapter named `awesome_adapter` together with the adapter card to the new repository.
+    `adapterhub_tag` and `datasets_tag` provide additional information for categorization.
+
+    ```eval_rst
+    .. important::
+        All adapters uploaded to HuggingFace's Model Hub are automatically also listed on AdapterHub.ml. Thus, for better categorization, either ``adapterhub_tag`` or ``datasets_tag`` is required when uploading a new adapter to the Model Hub.
+
+        - ``adapterhub_tag`` specifies the AdapterHub categorization of the adapter in the format ``<task>/<subtask>`` according to the tasks and subtasks shown on https://adapterhub.ml/explore. For more, see `Add a new task or subtask <https://docs.adapterhub.ml/contributing.html#add-a-new-task-or-subtask>`_.
+        - ``datasets_tag`` specifies the dataset the adapter was trained on as an identifier from `HuggingFace Datasets <https://huggingface.co/datasets>`_.
+    ```
+
+Voilà! Your first adapter is on the HuggingFace Model Hub.
+Anyone can now run:
+```
+model.load_adapter("<your_username>/my-awesome-adapter", source="hf")
+```
+
+To update your adapter, simply run `push_adapter_to_hub()` with the same repository name again. This will push a new commit to the existing repository.
+
+You can find the full documentation of `push_adapter_to_hub()` [here](classes/model_mixins.html#transformers.adapters.hub_mixin.PushAdapterToHubMixin.push_adapter_to_hub).

--- a/adapter_docs/index.rst
+++ b/adapter_docs/index.rst
@@ -40,6 +40,7 @@ Currently, we support the PyTorch versions of all models listed in the *Supporte
 
    loading
    contributing
+   huggingface_hub
 
 .. toctree::
    :maxdepth: 2

--- a/adapter_docs/loading.md
+++ b/adapter_docs/loading.md
@@ -20,7 +20,14 @@ In the minimal case, that's everything we need to specify to load a pre-trained 
 To examine what's happening underneath in a bit more detail, let's first write out the full method call with all relevant arguments explicitly stated:
 
 ```python
-model.load_adapter('sst-2', config='pfeiffer', model_name='bert-base-uncased', version=1, load_as='sst')
+model.load_adapter(
+    'sst-2',
+    config='pfeiffer',
+    model_name='bert-base-uncased',
+    version=1,
+    load_as='sst',
+    source='ah'
+)
 ```
 
 We will go through the different arguments and their meaning one by one:
@@ -39,6 +46,9 @@ If possible, the library will infer the name of the pre-trained model automatica
 
 - By default, the `load_adapter()` method will add the loaded adapter using the identifier string given as the first argument.
 To load the adapter using a custom name, we can use the `load_as` parameter.
+
+- Finally the `source` parameter provides the possibility to load adapters from alternative adapter repositories.
+Besides the default value `ah`, referring to AdapterHub, it's also possible to pass `hf` to [load adapters from HuggingFace's Model Hub](huggingface_hub.md).
 
 ## How adapter resolving works
 

--- a/src/transformers/adapters/hub_mixin.py
+++ b/src/transformers/adapters/hub_mixin.py
@@ -1,0 +1,197 @@
+import logging
+import os
+import shutil
+import stat
+import tempfile
+from typing import List, Optional, Union
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TEXT = "<!-- Add some description here -->"
+ADAPTER_CARD_TEMPLATE = """
+---
+tags:
+{tags}
+---
+
+# Adapter `{adapter_repo_name}` for {model_name}
+
+An [adapter](https://adapterhub.ml) for the {model_name} model that was trained on the {dataset_name} dataset{head_info}.
+
+This adapter was created for usage with the **[adapter-transformers](https://github.com/Adapter-Hub/adapter-transformers)** library.
+
+## Usage
+
+First, install `adapter-transformers`:
+
+```
+pip install -U adapter-transformers
+```
+_Note: adapter-transformers is a fork of transformers that acts as a drop-in replacement with adapter support. [More](https://docs.adapterhub.ml/installation.html)_
+
+Now, the adapter can be loaded and activated like this:
+
+```python
+from transformers import AutoModelWithHeads
+
+model = AutoModelWithHeads.from_pretrained("{model_name}")
+adapter_name = model.load_adapter("{adapter_repo_name}")
+model.active_adapters = adapter_name
+```
+
+## Architecture & Training
+
+{architecture_training}
+
+## Evaluation results
+
+{results}
+
+## Citation
+
+{citation}
+
+"""
+
+
+class PushAdapterToHubMixin:
+    """Mixin providing support for uploading adapters to HuggingFace's model hub."""
+
+    def _save_adapter_card(
+        self,
+        save_directory: str,
+        adapter_name: str,
+        adapter_repo_name: str,
+        adapterhub_tag: Optional[str] = None,
+        datasets_tag: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        **kwargs
+    ):
+        all_tags = {"adapter-transformers"}
+        datasets = set()
+        # Dataset/ Task info
+        dataset_name = None
+        if adapterhub_tag is None and datasets_tag is None:
+            raise ValueError("Either adapterhub_tag or datasets_tag must be specified.")
+        if datasets_tag is not None:
+            dataset_name = f"[{datasets_tag}](https://huggingface.co/datasets/{datasets_tag}/)"
+            datasets.add(datasets_tag)
+        if adapterhub_tag is not None:
+            # adapterhub_tag overwrites datasets_tag
+            dataset_name = f"[{adapterhub_tag}](https://adapterhub.ml/explore/{adapterhub_tag}/)"
+            all_tags.add(f"adapterhub:{adapterhub_tag}")
+
+        all_tags.add(self.config.model_type)
+        if tags is not None:
+            all_tags = all_tags | set(tags)
+        tag_string = "\n".join([f"- {tag}" for tag in all_tags])
+        if datasets:
+            tag_string += "\ndatasets:\n"
+            tag_string += "\n".join([f"- {tag}" for tag in datasets])
+
+        if hasattr(self, "heads") and adapter_name in self.heads:
+            head_config = self.heads[adapter_name].config
+            head_info = f" and includes a prediction head for {head_config['head_type']}"
+        else:
+            head_info = ""
+
+        adapter_card = ADAPTER_CARD_TEMPLATE.format(
+            tags=tag_string,
+            model_name=self.model_name,
+            dataset_name=dataset_name,
+            head_info=head_info,
+            adapter_repo_name=adapter_repo_name,
+            architecture_training=kwargs.pop("architecture_training", DEFAULT_TEXT),
+            results=kwargs.pop("results", DEFAULT_TEXT),
+            citation=kwargs.pop("citation", DEFAULT_TEXT),
+        )
+
+        logger.info("Saving adapter card for adapter \"%s\" to %s.", adapter_name, save_directory)
+        with open(os.path.join(save_directory, "README.md"), "w") as f:
+            f.write(adapter_card.strip())
+
+    def push_adapter_to_hub(
+        self,
+        repo_name: str,
+        adapter_name: str,
+        organization: Optional[str] = None,
+        adapterhub_tag: Optional[str] = None,
+        datasets_tag: Optional[str] = None,
+        use_local_path: Optional[str] = None,
+        commit_message: Optional[str] = None,
+        private: Optional[bool] = None,
+        use_auth_token: Union[bool, str] = True,
+        overwrite_adapter_card: bool = False,
+    ):
+        """Upload an adapter to HuggingFace's model hub.
+
+        Args:
+            repo_name (str): The name of the repository on the model hub to upload to.
+            adapter_name (str): The name of the adapter to be uploaded.
+            organization (str, optional): Organization in which to push the adapter
+                (you must be a member of this organization). Defaults to None.
+            adapterhub_tag (str, optional): Tag of the format `<task>/<subtask>` for categorization on https://adapterhub.ml/explore/.
+                See https://docs.adapterhub.ml/contributing.html#tasks-and-subtasks for more.
+                If not specified, `datasets_tag` must be given in case a new adapter card is generated. Defaults to None.
+            datasets_tag (str, optional): Dataset identifier from https://huggingface.co/datasets.
+                If not specified, `adapterhub_tag` must be given in case a new adapter card is generated. Defaults to None.
+            use_local_path (str, optional): Local path used as clone directory of the adapter repository.
+                If not specified, will create a temporary directory. Defaults to None.
+            commit_message (:obj:`str`, `optional`):
+                Message to commit while pushing. Will default to :obj:`"add config"`, :obj:`"add tokenizer"` or
+                :obj:`"add model"` depending on the type of the class.
+            private (:obj:`bool`, `optional`):
+                Whether or not the repository created should be private (requires a paying subscription).
+            use_auth_token (:obj:`bool` or :obj:`str`, `optional`):
+                The token to use as HTTP bearer authorization for remote files. If :obj:`True`, will use the token
+                generated when running :obj:`transformers-cli login` (stored in :obj:`~/.huggingface`). Defaults to True.
+            overwrite_adapter_card (bool, optional): Overwrite an existing adapter card with a newly generated one.
+                If set to `False`, will only generate an adapter card, if none exists. Defaults to False.
+
+        Returns:
+            str: The url of the adapter repository on the model hub.
+        """
+        repo_url = self._get_repo_url_from_name(
+            repo_name, organization=organization, private=private, use_auth_token=use_auth_token
+        )
+        if use_local_path is not None:
+            repo_path = use_local_path
+        else:
+            repo_path = tempfile.mkdtemp()
+        # Create repo or get retrieve an existing repo
+        repo = self._create_or_get_repo(
+            repo_path_or_name=repo_path,
+            repo_url=repo_url,
+            organization=organization,
+            private=private,
+            use_auth_token=use_auth_token,
+        )
+        # Save adapter and optionally create model card
+        self.save_adapter(repo_path, adapter_name)
+        if overwrite_adapter_card or not os.path.exists(os.path.join(repo_path, "README.md")):
+            full_repo_name = "/".join(repo_url.split("/")[-2:])
+            self._save_adapter_card(
+                repo_path,
+                adapter_name,
+                full_repo_name,
+                adapterhub_tag=adapterhub_tag,
+                datasets_tag=datasets_tag,
+            )
+        # Commit and push
+        logger.info(f"Pushing adapter \"{adapter_name}\" to model hub at {repo_url}...")
+        url = self._push_to_hub(repo, commit_message=commit_message)
+
+        # Clean up if temp dir was used
+        if use_local_path is None:
+            def on_rm_error(func, path, exc_info):
+                # path contains the path of the file that couldn't be removed
+                # let's just assume that it's read-only and unlink it.
+                try:
+                    os.chmod(path, stat.S_IWRITE)
+                    os.unlink(path)
+                except Exception:
+                    pass
+            shutil.rmtree(repo_path, onerror=on_rm_error)
+
+        return url

--- a/src/transformers/adapters/hub_mixin.py
+++ b/src/transformers/adapters/hub_mixin.py
@@ -118,7 +118,7 @@ class PushAdapterToHubMixin:
         organization: Optional[str] = None,
         adapterhub_tag: Optional[str] = None,
         datasets_tag: Optional[str] = None,
-        use_local_path: Optional[str] = None,
+        local_path: Optional[str] = None,
         commit_message: Optional[str] = None,
         private: Optional[bool] = None,
         use_auth_token: Union[bool, str] = True,
@@ -136,7 +136,7 @@ class PushAdapterToHubMixin:
                 If not specified, `datasets_tag` must be given in case a new adapter card is generated. Defaults to None.
             datasets_tag (str, optional): Dataset identifier from https://huggingface.co/datasets.
                 If not specified, `adapterhub_tag` must be given in case a new adapter card is generated. Defaults to None.
-            use_local_path (str, optional): Local path used as clone directory of the adapter repository.
+            local_path (str, optional): Local path used as clone directory of the adapter repository.
                 If not specified, will create a temporary directory. Defaults to None.
             commit_message (:obj:`str`, `optional`):
                 Message to commit while pushing. Will default to :obj:`"add config"`, :obj:`"add tokenizer"` or
@@ -155,8 +155,8 @@ class PushAdapterToHubMixin:
         repo_url = self._get_repo_url_from_name(
             repo_name, organization=organization, private=private, use_auth_token=use_auth_token
         )
-        if use_local_path is not None:
-            repo_path = use_local_path
+        if local_path is not None:
+            repo_path = local_path
         else:
             repo_path = tempfile.mkdtemp()
         # Create repo or get retrieve an existing repo
@@ -183,7 +183,7 @@ class PushAdapterToHubMixin:
         url = self._push_to_hub(repo, commit_message=commit_message)
 
         # Clean up if temp dir was used
-        if use_local_path is None:
+        if local_path is None:
 
             def on_rm_error(func, path, exc_info):
                 # path contains the path of the file that couldn't be removed

--- a/src/transformers/adapters/hub_mixin.py
+++ b/src/transformers/adapters/hub_mixin.py
@@ -56,7 +56,7 @@ model.active_adapters = adapter_name
 
 
 class PushAdapterToHubMixin:
-    """Mixin providing support for uploading adapters to HuggingFace's model hub."""
+    """Mixin providing support for uploading adapters to HuggingFace's Model Hub."""
 
     def _save_adapter_card(
         self,
@@ -107,7 +107,7 @@ class PushAdapterToHubMixin:
             citation=kwargs.pop("citation", DEFAULT_TEXT),
         )
 
-        logger.info("Saving adapter card for adapter \"%s\" to %s.", adapter_name, save_directory)
+        logger.info('Saving adapter card for adapter "%s" to %s.', adapter_name, save_directory)
         with open(os.path.join(save_directory, "README.md"), "w") as f:
             f.write(adapter_card.strip())
 
@@ -124,7 +124,7 @@ class PushAdapterToHubMixin:
         use_auth_token: Union[bool, str] = True,
         overwrite_adapter_card: bool = False,
     ):
-        """Upload an adapter to HuggingFace's model hub.
+        """Upload an adapter to HuggingFace's Model Hub.
 
         Args:
             repo_name (str): The name of the repository on the model hub to upload to.
@@ -132,7 +132,7 @@ class PushAdapterToHubMixin:
             organization (str, optional): Organization in which to push the adapter
                 (you must be a member of this organization). Defaults to None.
             adapterhub_tag (str, optional): Tag of the format `<task>/<subtask>` for categorization on https://adapterhub.ml/explore/.
-                See https://docs.adapterhub.ml/contributing.html#tasks-and-subtasks for more.
+                See https://docs.adapterhub.ml/contributing.html#add-a-new-task-or-subtask for more.
                 If not specified, `datasets_tag` must be given in case a new adapter card is generated. Defaults to None.
             datasets_tag (str, optional): Dataset identifier from https://huggingface.co/datasets.
                 If not specified, `adapterhub_tag` must be given in case a new adapter card is generated. Defaults to None.
@@ -179,11 +179,12 @@ class PushAdapterToHubMixin:
                 datasets_tag=datasets_tag,
             )
         # Commit and push
-        logger.info(f"Pushing adapter \"{adapter_name}\" to model hub at {repo_url}...")
+        logger.info('Pushing adapter "%s" to model hub at %s ...', adapter_name, repo_url)
         url = self._push_to_hub(repo, commit_message=commit_message)
 
         # Clean up if temp dir was used
         if use_local_path is None:
+
             def on_rm_error(func, path, exc_info):
                 # path contains the path of the file that couldn't be removed
                 # let's just assume that it's read-only and unlink it.
@@ -192,6 +193,7 @@ class PushAdapterToHubMixin:
                     os.unlink(path)
                 except Exception:
                     pass
+
             shutil.rmtree(repo_path, onerror=on_rm_error)
 
         return url

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -14,6 +14,7 @@ from .configuration import (
     ModelAdaptersConfig,
     get_adapter_config_hash,
 )
+from .hub_mixin import PushAdapterToHubMixin
 from .loading import AdapterFusionLoader, AdapterLoader, PredictionHeadLoader, WeightsLoader
 from .modeling import Adapter, GLOWCouplingBlock, NICECouplingBlock
 from .utils import inherit_doc
@@ -101,7 +102,7 @@ class ModelConfigAdaptersMixin(ABC):
             self.adapters = ModelAdaptersConfig()
 
 
-class ModelAdaptersMixin(ABC):
+class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
     """Mixin for transformer models adding support for loading/ saving adapters."""
 
     def __init__(self, config, *args, **kwargs):


### PR DESCRIPTION
Follow-up to #162.

Similar to `push_to_hub()` in `transformers`, this PR adds a new method `push_adapter_to_hub()` that allows pushing a loaded adapter by name, e.g.:
```python
model.push_adapter_to_hub(
    "my-awesome-adapter",  # repo name
    "awesome_adapter",  # adapter name
    adapterhub_tag="sentiment/imdb",
    datasets_tag="imdb"
)
```
One of the two args `adapterhub_tag` and `datasets_tag` is required, so we can automatically pull adapters from huggingface.co to AdapterHub.ml with correct categorization.

Also added a new doc page (`adapter_docs/huggingface_hub.md`) for describing the HF Model Hub integration.

cc @osanseviero just fyi :)