### PR TITLE
Rename layer_norm -> transformer_layer_norm in adapter layer

### DIFF
--- a/src/transformers/adapters/layer.py
+++ b/src/transformers/adapters/layer.py
@@ -16,7 +16,7 @@ class AdapterLayerBaseMixin(ABC):
 
     # override this property if layer norm has a different name
     @property
-    def layer_norm(self):
+    def transformer_layer_norm(self):
         return self.LayerNorm
 
     @property
@@ -135,8 +135,8 @@ class AdapterLayerBaseMixin(ABC):
             query = hidden_states
 
         if adapter_config["original_ln_before"]:
-            if self.layer_norm:
-                hidden_states = self.layer_norm(hidden_states + input_tensor)
+            if self.transformer_layer_norm:
+                hidden_states = self.transformer_layer_norm(hidden_states + input_tensor)
             else:
                 hidden_states = hidden_states + input_tensor
 
@@ -455,13 +455,13 @@ class AdapterLayerBaseMixin(ABC):
 
             last_config = self.config.adapters.get(adapter_setup.last())
             if last_config["original_ln_after"]:
-                if self.layer_norm:
-                    hidden_states = self.layer_norm(hidden_states + input_tensor)
+                if self.transformer_layer_norm:
+                    hidden_states = self.transformer_layer_norm(hidden_states + input_tensor)
                 else:
                     hidden_states = hidden_states + input_tensor
 
-        elif self.layer_norm:
-            hidden_states = self.layer_norm(hidden_states + input_tensor)
+        elif self.transformer_layer_norm:
+            hidden_states = self.transformer_layer_norm(hidden_states + input_tensor)
         else:
             hidden_states = hidden_states + input_tensor
 

--- a/src/transformers/adapters/models/bart.py
+++ b/src/transformers/adapters/models/bart.py
@@ -26,7 +26,7 @@ class BartSelfAttentionAdaptersModule(AdapterLayerBaseMixin, nn.Module):
         return "mh_adapter"
 
     @property
-    def layer_norm(self):
+    def transformer_layer_norm(self):
         # MBart has layer norms before each component
         if self.config.model_type == "mbart":
             return None
@@ -46,7 +46,7 @@ class BartCrossAttentionAdaptersModule(AdapterLayerBaseMixin, nn.Module):
         return "cross_adapter"
 
     @property
-    def layer_norm(self):
+    def transformer_layer_norm(self):
         # MBart has layer norms before each component
         if self.config.model_type == "mbart":
             return None
@@ -66,7 +66,7 @@ class BartOutputAdaptersModule(AdapterLayerBaseMixin, nn.Module):
         return "output_adapter"
 
     @property
-    def layer_norm(self):
+    def transformer_layer_norm(self):
         # MBart has layer norms before each component
         if self.config.model_type == "mbart":
             return None

--- a/src/transformers/adapters/models/distilbert.py
+++ b/src/transformers/adapters/models/distilbert.py
@@ -18,7 +18,7 @@ class DistilBertSelfAttentionAdaptersModule(BertSelfOutputAdaptersMixin, nn.Modu
         self.config = parent.config
 
     @property
-    def layer_norm(self):
+    def transformer_layer_norm(self):
         return self.parent.sa_layer_norm
 
 
@@ -32,7 +32,7 @@ class DistilBertOutputAdaptersModule(BertOutputAdaptersMixin, nn.Module):
         self.config = parent.config
 
     @property
-    def layer_norm(self):
+    def transformer_layer_norm(self):
         return self.parent.output_layer_norm
 
 

--- a/src/transformers/adapters/models/gpt2.py
+++ b/src/transformers/adapters/models/gpt2.py
@@ -24,7 +24,7 @@ class GPT2AttentionAdaptersModule(BertSelfOutputAdaptersMixin, nn.Module):
         self.config = parent.config
 
     @property
-    def layer_norm(self):
+    def transformer_layer_norm(self):
         return None
 
 
@@ -38,7 +38,7 @@ class GPT2OutputAdaptersModule(BertOutputAdaptersMixin, nn.Module):
         self.config = parent.config
 
     @property
-    def layer_norm(self):
+    def transformer_layer_norm(self):
         return None
 
 


### PR DESCRIPTION
Change is required for T5 implementation in #182 to avoid name clashes.