### PR TITLE
Add `set_active` argument to add & load adapter/fusion/head methods

### DIFF
--- a/src/transformers/adapters/heads.py
+++ b/src/transformers/adapters/heads.py
@@ -393,7 +393,13 @@ class ModelWithFlexibleHeadsAdaptersMixin(ModelWithHeadsAdaptersMixin):
         for head_name, config in self.config.prediction_heads.items():
             self.add_prediction_head_from_config(head_name, config)
 
-    def add_prediction_head_from_config(self, head_name, config, overwrite_ok=False):
+    def add_prediction_head_from_config(
+        self,
+        head_name: str,
+        config: dict,
+        overwrite_ok: bool = False,
+        set_active: bool = True,
+    ):
         head_type = config.pop("head_type")
         # handle cases when id2label, label2id or both are available
         id2label = config.pop("id2label", None)
@@ -407,7 +413,7 @@ class ModelWithFlexibleHeadsAdaptersMixin(ModelWithHeadsAdaptersMixin):
         if head_type in self.head_types:
             head_class = self.head_types[head_type]
             head = head_class(self, head_name, id2label=id2label, **config)
-            self.add_prediction_head(head, overwrite_ok=overwrite_ok)
+            self.add_prediction_head(head, overwrite_ok=overwrite_ok, set_active=set_active)
         elif head_type in self.config.custom_heads:
             # we have to re-add the head type for custom heads
             config["head_type"] = head_type
@@ -497,10 +503,10 @@ class ModelWithFlexibleHeadsAdaptersMixin(ModelWithHeadsAdaptersMixin):
             else:
                 logger.info("Could not identify '{}' as a valid prediction head.".format(final_block))
 
-    def add_custom_head(self, head_name, config, overwrite_ok=False):
+    def add_custom_head(self, head_name, config, overwrite_ok=False, set_active=True):
         if config["head_type"] in self.config.custom_heads:
             head = self.config.custom_heads[config["head_type"]](head_name, config, self)
-            self.add_prediction_head(head, overwrite_ok)
+            self.add_prediction_head(head, overwrite_ok, set_active=set_active)
         else:
             raise AttributeError(
                 "The given head as a head_type that is not registered as a custom head yet."
@@ -511,6 +517,7 @@ class ModelWithFlexibleHeadsAdaptersMixin(ModelWithHeadsAdaptersMixin):
         self,
         head: PredictionHead,
         overwrite_ok: bool = False,
+        set_active: bool = True,
     ):
 
         if head.name not in self.heads or overwrite_ok:
@@ -525,7 +532,8 @@ class ModelWithFlexibleHeadsAdaptersMixin(ModelWithHeadsAdaptersMixin):
                     head.config["label2id"] = {"LABEL_" + str(num): num for num in range(head.config["num_choices"])}
 
             logger.info(f"Adding head '{head.name}' with config {head.config}.")
-            self.active_head = head.name
+            if set_active:
+                self.active_head = head.name
 
         else:
             raise ValueError(

--- a/tests/test_adapter_common.py
+++ b/tests/test_adapter_common.py
@@ -223,8 +223,8 @@ class AdapterModelTestMixin:
         with tempfile.TemporaryDirectory() as temp_dir:
             model1.save_adapter(temp_dir, name)
 
-            model2.load_adapter(temp_dir)
-            model2.set_active_adapters([name])
+            # also tests that set_active works
+            model2.load_adapter(temp_dir, set_active=True)
 
         # check if adapter was correctly loaded
         self.assertTrue(name in model2.config.adapters)

--- a/tests/test_adapter_fusion_common.py
+++ b/tests/test_adapter_fusion_common.py
@@ -89,17 +89,18 @@ class AdapterFusionModelTestMixin:
                 model2.eval()
 
                 model1.add_adapter_fusion([name1, name2], adater_fusion_config_name)
+                model1.set_active_adapters([[name1, name2]])
+
                 with tempfile.TemporaryDirectory() as temp_dir:
                     model1.save_adapter_fusion(temp_dir, ",".join([name1, name2]))
-                    model2.load_adapter_fusion(temp_dir)
+                    # also tests that set_active works
+                    model2.load_adapter_fusion(temp_dir, set_active=True)
 
                 # check if adapter was correctly loaded
                 self.assertTrue(model1.config.adapter_fusion_models == model2.config.adapter_fusion_models)
 
                 # check equal output
                 in_data = self.get_input_samples((1, 128), config=model1.config)
-                model1.set_active_adapters([[name1, name2]])
-                model2.set_active_adapters([[name1, name2]])
                 output1 = model1(in_data)
                 output2 = model2(in_data)
                 self.assertEqual(len(output1), len(output2))

--- a/tests/test_adapter_heads.py
+++ b/tests/test_adapter_heads.py
@@ -217,5 +217,5 @@ class PredictionHeadModelTestMixin:
         # check equal output
         in_data = self.get_input_samples((1, 128), config=flex_head_model.config)
         output1 = static_head_model(in_data, adapter_names=["test"])
-        output2 = flex_head_model(in_data, adapter_names=["test"])
+        output2 = flex_head_model(in_data, adapter_names=["test"], head="test")
         self.assertTrue(torch.all(torch.isclose(output1.logits, output2.logits)))

--- a/tests/test_adapter_hub.py
+++ b/tests/test_adapter_hub.py
@@ -115,7 +115,9 @@ class AdapterHubTest(unittest.TestCase):
                 config = AdapterConfig.load(config, non_linearity="gelu", reduction_factor=2)
 
                 loading_info = {}
-                adapter_name = model.load_adapter("fi/wiki@ukp", config=config, loading_info=loading_info)
+                adapter_name = model.load_adapter(
+                    "fi/wiki@ukp", config=config, set_active=True, loading_info=loading_info
+                )
 
                 self.assertEqual(0, len(loading_info["missing_keys"]))
                 self.assertEqual(0, len(loading_info["unexpected_keys"]))
@@ -139,7 +141,9 @@ class AdapterHubTest(unittest.TestCase):
         model = BertModelWithHeads.from_pretrained("bert-base-uncased")
 
         loading_info = {}
-        adapter_name = model.load_adapter("qa/squad1@ukp", config="houlsby", version="1", loading_info=loading_info)
+        adapter_name = model.load_adapter(
+            "qa/squad1@ukp", config="houlsby", version="1", set_active=True, loading_info=loading_info
+        )
 
         self.assertEqual(0, len(loading_info["missing_keys"]))
         self.assertEqual(0, len(loading_info["unexpected_keys"]))


### PR DESCRIPTION
There currently is a slightly unintuitive inconsistency in the library: when adding an adapter with `add_adapter()`/ `load_adapter()`, it is never activated, however (flex) heads (added either via `add_x_head()`/ `load_head()` or `load_adapter()`) are always activated.

This PR adds an additional `set_active` parameter to all adding/ loading method that allows direct activation of a loaded adapter/ fusion/ head. For compatibility, it is set to `False` by default for `add_adapter()`/`load_adapter()` and to `True` for `load_head()`.