### PR TITLE
Improve AdapterFusion config flexibility

### DIFF
--- a/src/transformers/adapters/layer.py
+++ b/src/transformers/adapters/layer.py
@@ -75,7 +75,12 @@ class AdapterLayerBaseMixin(ABC):
         """See BertModel.add_fusion_layer"""
         adapter_names = adapter_names if isinstance(adapter_names, list) else adapter_names.split(",")
         if self.config.adapters.common_config_value(adapter_names, self.adapter_config_key):
-            fusion = BertFusion(self.config)
+            fusion_config = self.config.adapters.get_fusion(adapter_names)
+            fusion = BertFusion(
+                fusion_config,
+                self.config.hidden_size,
+                self.config.attention_probs_dropout_prob,
+            )
             fusion.train(self.training)  # make sure training mode is consistent
             self.adapter_fusion_layer[",".join(adapter_names)] = fusion
 
@@ -114,6 +119,7 @@ class AdapterLayerBaseMixin(ABC):
         adapter_config,
         hidden_states,
         input_tensor,
+        fusion_config=None,
     ):
         """
         Retrieves the hidden_states, query (for Fusion), and residual connection according to the set configuratio
@@ -131,7 +137,7 @@ class AdapterLayerBaseMixin(ABC):
         if adapter_config["residual_before_ln"]:
             residual = hidden_states
 
-        if hasattr(self.config, "adapter_fusion") and self.config.adapter_fusion["query_before_ln"]:
+        if fusion_config is not None and fusion_config["query_before_ln"]:
             query = hidden_states
 
         if adapter_config["original_ln_before"]:
@@ -143,7 +149,7 @@ class AdapterLayerBaseMixin(ABC):
         if not adapter_config["residual_before_ln"]:
             residual = hidden_states
 
-        if hasattr(self.config, "adapter_fusion") and not self.config.adapter_fusion["query_before_ln"]:
+        if fusion_config is not None and not fusion_config["query_before_ln"]:
             query = hidden_states
 
         return hidden_states, query, residual
@@ -196,7 +202,10 @@ class AdapterLayerBaseMixin(ABC):
         """
         # config of _last_ fused adapter is significant
         adapter_config = self.config.adapters.get(adapter_setup.last())
-        hidden_states, query, residual = self.get_adapter_preparams(adapter_config, hidden_states, input_tensor)
+        fusion_config = self.config.adapters.get_fusion(adapter_setup.name)
+        hidden_states, query, residual = self.get_adapter_preparams(
+            adapter_config, hidden_states, input_tensor, fusion_config=fusion_config
+        )
 
         up_list = []
 
@@ -239,7 +248,7 @@ class AdapterLayerBaseMixin(ABC):
         """
         # config of _first_ of splitted adapters is significant
         adapter_config = self.config.adapters.get(adapter_setup.first())
-        hidden_states, query, residual = self.get_adapter_preparams(adapter_config, hidden_states, input_tensor)
+        hidden_states, _, residual = self.get_adapter_preparams(adapter_config, hidden_states, input_tensor)
 
         # split hidden representations and residuals at split index
         split_hidden_states = [

--- a/src/transformers/adapters/loading.py
+++ b/src/transformers/adapters/loading.py
@@ -521,7 +521,7 @@ class AdapterFusionLoader(WeightsLoader):
         adapter_fusion_name = load_as or config["name"]
         if adapter_fusion_name in self.model.config.adapters.fusions:
             logger.warning("Overwriting existing adapter fusion module '{}'".format(adapter_fusion_name))
-        self.model.add_adapter_fusion(adapter_fusion_name, config["config"])
+        self.model.add_adapter_fusion(adapter_fusion_name, config["config"], overwrite_ok=True)
 
         # Load AdapterFusion weights
         filter_func = self.filter_func(adapter_fusion_name)

--- a/src/transformers/adapters/loading.py
+++ b/src/transformers/adapters/loading.py
@@ -522,7 +522,9 @@ class AdapterFusionLoader(WeightsLoader):
         adapter_fusion_name = load_as or config["name"]
         if adapter_fusion_name in self.model.config.adapters.fusions:
             logger.warning("Overwriting existing adapter fusion module '{}'".format(adapter_fusion_name))
-        self.model.add_adapter_fusion(adapter_fusion_name, config["config"], overwrite_ok=True, set_active=kwargs.pop("set_active", True))
+        self.model.add_adapter_fusion(
+            adapter_fusion_name, config["config"], overwrite_ok=True, set_active=kwargs.pop("set_active", True)
+        )
 
         # Load AdapterFusion weights
         filter_func = self.filter_func(adapter_fusion_name)

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -470,7 +470,7 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
             save_directory (str): Path to a directory where the adapters should be saved.
         """
         for name in self.config.adapters.fusions:
-            adapter_fusion_config = self.config.adapters.get_fusions(name)
+            adapter_fusion_config = self.config.adapters.get_fusion(name)
             h = get_adapter_config_hash(adapter_fusion_config)
             save_path = join(save_directory, name)
             if meta_dict:

--- a/src/transformers/adapters/modeling.py
+++ b/src/transformers/adapters/modeling.py
@@ -3,6 +3,8 @@ import math
 import torch
 from torch import nn
 
+from .configuration import AdapterFusionConfig
+
 
 class Activation_Function_Class(nn.Module):
     """
@@ -146,42 +148,40 @@ class BertFusion(nn.Module):
     Implementation of an AdapterFusion block.
     """
 
-    def __init__(self, config):
+    def __init__(
+        self,
+        config: AdapterFusionConfig,
+        dense_size,
+        attention_probs_dropout_prob,
+    ):
         super(BertFusion, self).__init__()
         # if config.hidden_size % config.num_attention_heads != 0:
         #     raise ValueError(
         #         "The hidden size (%d) is not a multiple of the number of attention "
         #         "heads (%d)" % (config.hidden_size, config.num_attention_heads))
         self.config = config
-        self.output_attentions = config.output_attentions
 
-        self.dense_size = int(config.hidden_size)
-        self.dropout = nn.Dropout(config.attention_probs_dropout_prob)
+        self.dense_size = dense_size
+        self.dropout = nn.Dropout(attention_probs_dropout_prob)
 
-        if (
-            not self.config.adapter_fusion["query"]
-            and not self.config.adapter_fusion["key"]
-            and not self.config.adapter_fusion["value"]
-        ):
+        if not self.config["query"] and not self.config["key"] and not self.config["value"]:
             self.dense = nn.Linear(self.dense_size, 1)
 
-        if self.config.adapter_fusion["query"]:
-            self.query = nn.Linear(int(config.hidden_size), self.dense_size)
+        if self.config["query"]:
+            self.query = nn.Linear(self.dense_size, self.dense_size)
             self.query.apply(Adapter.init_bert_weights)
 
-        if self.config.adapter_fusion["key"]:
+        if self.config["key"]:
             self.key = nn.Linear(self.dense_size, self.dense_size)
             self.key.apply(Adapter.init_bert_weights)
 
-        if self.config.adapter_fusion["value"]:
-            self.value = nn.Linear(int(config.hidden_size), int(config.hidden_size), bias=False)
+        if self.config["value"]:
+            self.value = nn.Linear(self.dense_size, self.dense_size, bias=False)
             self.value.apply(Adapter.init_bert_weights)
-            if self.config.adapter_fusion["value_initialized"]:
-                self.value.weight.data = (
-                    torch.zeros(int(config.hidden_size), int(config.hidden_size)) + 0.000001
-                ).fill_diagonal_(1.0)
+            if self.config["value_initialized"]:
+                self.value.weight.data = (torch.zeros(self.dense_size, self.dense_size) + 0.000001).fill_diagonal_(1.0)
 
-        if self.config.adapter_fusion["temperature"]:
+        if self.config["temperature"]:
             self.T = 50.0
         else:
             self.T = 1.0
@@ -189,20 +189,20 @@ class BertFusion(nn.Module):
 
     def forward(self, query, key, value, residual):
 
-        if self.config.adapter_fusion["residual_before"]:
+        if self.config["residual_before"]:
             value += residual[:, :, None, :].repeat(1, 1, value.size(2), 1)
 
-        if self.config.adapter_fusion["query"]:
+        if self.config["query"]:
             query_layer = self.query(query)
         else:
             query_layer = query
 
-        if self.config.adapter_fusion["key"]:
+        if self.config["key"]:
             key_layer = self.key(key)
         else:
             key_layer = key
 
-        if self.config.adapter_fusion["value"] and self.config.adapter_fusion["value_before_softmax"]:
+        if self.config["value"] and self.config["value_before_softmax"]:
             # key/value have dims => batch, toks, number-of-adapters, feats
             value_layer = self.value(value)
         else:
@@ -222,13 +222,13 @@ class BertFusion(nn.Module):
 
         context_layer = torch.squeeze(torch.matmul(attention_probs.unsqueeze(2), value_layer), dim=2)
 
-        if self.config.adapter_fusion["value"] and not self.config.adapter_fusion["value_before_softmax"]:
+        if self.config["value"] and not self.config["value_before_softmax"]:
             # key/value have dims => batch, toks, number-of-adapters, feats
             context_layer = self.value(context_layer)
         else:
             context_layer = context_layer
 
-        if not self.config.adapter_fusion["residual_before"]:
+        if not self.config["residual_before"]:
             context_layer += residual
 
         return context_layer

--- a/tests/test_adapter_fusion_common.py
+++ b/tests/test_adapter_fusion_common.py
@@ -53,7 +53,7 @@ class AdapterFusionModelTestMixin:
 
         # correct fusion
         model.add_adapter_fusion(["a", "b"])
-        self.assertIn("a,b", model.config.adapter_fusion_models)
+        self.assertIn("a,b", model.config.adapters.fusions)
         # failing fusion
         self.assertRaises(ValueError, lambda: model.add_adapter_fusion(["a", "c"]))
 
@@ -69,10 +69,10 @@ class AdapterFusionModelTestMixin:
         self.assertTrue(name2 in model.config.adapters)
 
         model.add_adapter_fusion([name1, name2])
-        self.assertTrue(",".join([name1, name2]) in model.config.adapter_fusion_models)
+        self.assertTrue(",".join([name1, name2]) in model.config.adapters.fusions)
 
         model.delete_adapter_fusion([name1, name2])
-        self.assertFalse(",".join([name1, name2]) in model.config.adapter_fusion_models)
+        self.assertFalse(",".join([name1, name2]) in model.config.adapters.fusions)
 
     def test_load_adapter_fusion(self):
         for adater_fusion_config_name, adapter_fusion_config in ADAPTERFUSION_CONFIG_MAP.items():
@@ -94,7 +94,7 @@ class AdapterFusionModelTestMixin:
                     model2.load_adapter_fusion(temp_dir)
 
                 # check if adapter was correctly loaded
-                self.assertTrue(model1.config.adapter_fusion_models == model2.config.adapter_fusion_models)
+                self.assertEqual(model1.config.adapters.fusions.keys(), model2.config.adapters.fusions.keys())
 
                 # check equal output
                 in_data = self.get_input_samples((1, 128), config=model1.config)
@@ -120,7 +120,7 @@ class AdapterFusionModelTestMixin:
             model2 = AutoModel.from_pretrained(temp_dir)
 
         # check if AdapterFusion was correctly loaded
-        self.assertTrue(model1.config.adapter_fusion_models == model2.config.adapter_fusion_models)
+        self.assertTrue(model1.config.adapters.fusions == model2.config.adapters.fusions)
 
         # check equal output
         in_data = self.get_input_samples((1, 128), config=model1.config)
@@ -140,6 +140,6 @@ class AdapterFusionModelTestMixin:
             model = AutoModel.from_config(self.config())
             model.add_adapter("test1")
             model.add_adapter("test2")
-            model.add_adapter_fusion(["test1", "test2"], adapter_fusion_config=v)
+            model.add_adapter_fusion(["test1", "test2"], config=v)
             # should not raise an exception
             model.config.to_json_string()

--- a/tests/test_adapter_trainer.py
+++ b/tests/test_adapter_trainer.py
@@ -131,8 +131,10 @@ class TestAdapterTrainer(unittest.TestCase):
                 intermediate_size=37,
             )
         )
-        model.add_adapter("adapter")
-        model.train_adapter("adapter")
+        model.add_adapter("adapter1")
+        model.add_adapter("adapter2")
+        model.add_adapter_fusion(Fuse("adapter1", "adapter2"))
+        model.train_adapter_fusion(Fuse("adapter1", "adapter2"))
 
         training_args = TrainingArguments(
             output_dir="./examples",


### PR DESCRIPTION
Move AF config to ModelAdaptersConfig. It's now possible to have multiple AF setups with different configs within one model.

Also removes `set_adapter_fusion_config()`.