### PR TITLE
Fix MBart adapter implementation

### DIFF
--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -326,7 +326,7 @@ class MBartEncoderLayer(BartEncoderLayerAdaptersMixin, nn.Module):
             output_attentions=output_attentions,
         )
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
-        hidden_states = self.attention_adapters(hidden_states, residual, self.self_attn_layer_norm)
+        hidden_states = self.attention_adapters(hidden_states, residual, None)
 
         residual = hidden_states
         hidden_states = self.final_layer_norm(hidden_states)
@@ -334,7 +334,7 @@ class MBartEncoderLayer(BartEncoderLayerAdaptersMixin, nn.Module):
         hidden_states = nn.functional.dropout(hidden_states, p=self.activation_dropout, training=self.training)
         hidden_states = self.fc2(hidden_states)
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
-        hidden_states = self.output_adapters(hidden_states, residual, self.final_layer_norm)
+        hidden_states = self.output_adapters(hidden_states, residual, None)
 
         if hidden_states.dtype == torch.float16 and (
             torch.isinf(hidden_states).any() or torch.isnan(hidden_states).any()
@@ -425,7 +425,7 @@ class MBartDecoderLayer(BartDecoderLayerAdaptersMixin, nn.Module):
             output_attentions=output_attentions,
         )
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
-        hidden_states = self.attention_adapters(hidden_states, residual, self.self_attn_layer_norm)
+        hidden_states = self.attention_adapters(hidden_states, residual, None)
 
         # Cross-Attention Block
         cross_attn_present_key_value = None
@@ -445,7 +445,7 @@ class MBartDecoderLayer(BartDecoderLayerAdaptersMixin, nn.Module):
                 output_attentions=output_attentions,
             )
             hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
-            hidden_states = self.cross_attention_adapters(hidden_states, residual, self.encoder_attn_layer_norm)
+            hidden_states = self.cross_attention_adapters(hidden_states, residual, None)
 
             # add cross-attn to positions 3,4 of present_key_value tuple
             present_key_value = present_key_value + cross_attn_present_key_value
@@ -457,7 +457,7 @@ class MBartDecoderLayer(BartDecoderLayerAdaptersMixin, nn.Module):
         hidden_states = nn.functional.dropout(hidden_states, p=self.activation_dropout, training=self.training)
         hidden_states = self.fc2(hidden_states)
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
-        hidden_states = self.output_adapters(hidden_states, residual, self.final_layer_norm)
+        hidden_states = self.output_adapters(hidden_states, residual, None)
 
         outputs = (hidden_states,)
 


### PR DESCRIPTION
MBart places layer norms before FF/ attention blocks. Thus, they shouldn't be passed to adapter layers.