### PR TITLE
adapters-trainer: add missing preprocess_logits_for_metrics argument

### DIFF
--- a/src/transformers/adapters/trainer.py
+++ b/src/transformers/adapters/trainer.py
@@ -48,6 +48,7 @@ class AdapterTrainer(Trainer):
         callbacks: Optional[List[TrainerCallback]] = None,
         adapter_names: Optional[List[List[str]]] = None,
         optimizers: Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
+        preprocess_logits_for_metrics: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] = None,
     ):
         super().__init__(
             model,
@@ -60,6 +61,7 @@ class AdapterTrainer(Trainer):
             compute_metrics=compute_metrics,
             callbacks=[AdapterTrainerCallback(self)] + callbacks if callbacks else [AdapterTrainerCallback(self)],
             optimizers=optimizers,
+            preprocess_logits_for_metrics=preprocess_logits_for_metrics,
         )
 
         if adapter_names is not None:


### PR DESCRIPTION
Hi,

I just wanted to train my first language adapter with the `run_mlm.py` example script. I also used a validation corpus, but training does not start due to this error message:

```bash
Traceback (most recent call last):                                                                                                                                            
  File "run_mlm.py", line 632, in <module>                                                                                                                                    
    main()                                                                                                                                                                    
  File "run_mlm.py", line 563, in main                                                                                                                                        
    trainer = trainer_class(                                                                        
TypeError: __init__() got an unexpected keyword argument 'preprocess_logits_for_metrics'
```

I did some debugging and the `preprocess_logits_for_metrics` argument is available for the upstream Transformers Trainer interface:

https://github.com/huggingface/transformers/blob/main/src/transformers/trainer.py#L291

But is currently not available for the Adapters Trainer interface. This PR adds the `preprocess_logits_for_metrics` argument to the interface. Training is then working :hugs: 