### PR TITLE
multi-gpu support for prefix-tuning

### DIFF
--- a/src/transformers/adapters/prefix_tuning.py
+++ b/src/transformers/adapters/prefix_tuning.py
@@ -3,12 +3,12 @@ from typing import List, Union
 import torch
 from torch import nn
 
+from ..modeling_utils import ModuleUtilsMixin
 from .composition import AdapterCompositionBlock
 from .configuration import PrefixTuningConfig
 from .context import AdapterSetup, ForwardContext
 from .layer import AdapterLayerBase
 from .modeling import Activation_Function_Class
-from ..modeling_utils import ModuleUtilsMixin
 
 
 class PrefixTuning(nn.Module, ModuleUtilsMixin):

--- a/src/transformers/adapters/prefix_tuning.py
+++ b/src/transformers/adapters/prefix_tuning.py
@@ -1,7 +1,6 @@
-from typing import List, Union
-
 import torch
 from torch import nn
+from typing import List, Union
 
 from .composition import AdapterCompositionBlock
 from .configuration import PrefixTuningConfig

--- a/src/transformers/adapters/prefix_tuning.py
+++ b/src/transformers/adapters/prefix_tuning.py
@@ -1,6 +1,7 @@
+from typing import List, Union
+
 import torch
 from torch import nn
-from typing import List, Union
 
 from .composition import AdapterCompositionBlock
 from .configuration import PrefixTuningConfig
@@ -59,7 +60,7 @@ class PrefixTuning(nn.Module, ModuleUtilsMixin):
         return key_values
 
 
-class FlatPrefixTuning(nn.Module):
+class FlatPrefixTuning(nn.Module, ModuleUtilsMixin):
     def __init__(
         self,
         n_layers: int,

--- a/src/transformers/adapters/prefix_tuning.py
+++ b/src/transformers/adapters/prefix_tuning.py
@@ -8,6 +8,7 @@ from .configuration import PrefixTuningConfig
 from .context import AdapterSetup, ForwardContext
 from .layer import AdapterLayerBase
 from .modeling import Activation_Function_Class
+from ..modeling_utils import get_parameter_device
 
 
 class PrefixTuning(nn.Module):
@@ -35,7 +36,7 @@ class PrefixTuning(nn.Module):
         self.dropout = nn.Dropout(self.config.dropout)
 
     def eject(self):
-        device = next(self.parameters()).device
+        device = get_parameter_device(self)
         input_tokens = self.input_tokens.unsqueeze(0).expand(1, -1).to(device)
         embs = self.wte(input_tokens)
         key_values = self.control_trans(embs)  # batch_size x prefix_length x n_layers*2*input_size
@@ -46,7 +47,7 @@ class PrefixTuning(nn.Module):
         return key_values
 
     def forward(self, batch_size):
-        device = next(self.parameters()).device
+        device = get_parameter_device(self)
         input_tokens = self.input_tokens.unsqueeze(0).expand(batch_size, -1).to(device)
         embs = self.wte(input_tokens)
         key_values = self.control_trans(embs)  # batch_size x prefix_length x n_layers*2*input_size
@@ -80,7 +81,7 @@ class FlatPrefixTuning(nn.Module):
         self.dropout = nn.Dropout(self.config.dropout)
 
     def forward(self, batch_size):
-        device = next(self.parameters()).device
+        device = get_parameter_device(self)
         key_values = (
             self.control_trans.unsqueeze(0)
             .expand(batch_size, -1)

--- a/src/transformers/adapters/prefix_tuning.py
+++ b/src/transformers/adapters/prefix_tuning.py
@@ -8,10 +8,10 @@ from .configuration import PrefixTuningConfig
 from .context import AdapterSetup, ForwardContext
 from .layer import AdapterLayerBase
 from .modeling import Activation_Function_Class
-from ..modeling_utils import get_parameter_device
+from ..modeling_utils import get_parameter_device, ModuleUtilsMixin
 
 
-class PrefixTuning(nn.Module):
+class PrefixTuning(nn.Module, ModuleUtilsMixin):
     def __init__(
         self,
         n_layers: int,


### PR DESCRIPTION
The current way of initializing `input_tokens` in `__init__` and using `device = next(self.parameters()).device` to find device does not work for multi-gpu.

Instead we should use this [fix](https://github.com/huggingface/transformers/blob/1c220ced8ecc5f12bc979239aa648747411f9fc4/src/transformers/modeling_utils.py#L120) to find the device of the module and assign it to the input tokens.