### PR TITLE
Fix issues with embedding training

### DIFF
--- a/src/transformers/adapters/mixins/bart.py
+++ b/src/transformers/adapters/mixins/bart.py
@@ -3,7 +3,13 @@ from typing import Iterable, Tuple
 import torch.nn as nn
 
 from ..layer import AdapterLayer
-from ..model_mixin import EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelAdaptersMixin
+from ..model_mixin import (
+    EmbeddingAdaptersMixin,
+    EmbeddingAdaptersWrapperMixin,
+    InvertibleAdaptersMixin,
+    ModelAdaptersMixin,
+    ModelWithHeadsAdaptersMixin,
+)
 
 
 class BartEncoderLayerAdaptersMixin:
@@ -48,3 +54,7 @@ class BartModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, Mo
             self.enable_invertible_adapters = self.encoder.enable_invertible_adapters
             self.invertible_adapters_forward = self.encoder.invertible_adapters_forward
         super()._init_adapter_modules()
+
+
+class BartModelWithHeadsAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdaptersMixin):
+    pass

--- a/src/transformers/adapters/mixins/bert.py
+++ b/src/transformers/adapters/mixins/bert.py
@@ -4,7 +4,13 @@ from typing import Iterable, Tuple
 import torch.nn as nn
 
 from ..layer import AdapterLayer
-from ..model_mixin import EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelAdaptersMixin
+from ..model_mixin import (
+    EmbeddingAdaptersMixin,
+    EmbeddingAdaptersWrapperMixin,
+    InvertibleAdaptersMixin,
+    ModelAdaptersMixin,
+    ModelWithHeadsAdaptersMixin,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -32,3 +38,7 @@ class BertModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, Mo
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
         for i, layer in enumerate(self.encoder.layer):
             yield i, layer
+
+
+class BertModelWithHeadsAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdaptersMixin):
+    pass

--- a/src/transformers/adapters/mixins/distilbert.py
+++ b/src/transformers/adapters/mixins/distilbert.py
@@ -3,7 +3,13 @@ from typing import Iterable, Tuple
 import torch.nn as nn
 
 from ..layer import AdapterLayer
-from ..model_mixin import EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelAdaptersMixin
+from ..model_mixin import (
+    EmbeddingAdaptersMixin,
+    EmbeddingAdaptersWrapperMixin,
+    InvertibleAdaptersMixin,
+    ModelAdaptersMixin,
+    ModelWithHeadsAdaptersMixin,
+)
 
 
 class DistilBertTransfomerBlockAdaptersMixin:
@@ -22,3 +28,7 @@ class DistilBertModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMix
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
         for i, layer in enumerate(self.transformer.layer):
             yield i, layer
+
+
+class DistilBertModelWithHeadsAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdaptersMixin):
+    pass

--- a/src/transformers/adapters/mixins/gpt2.py
+++ b/src/transformers/adapters/mixins/gpt2.py
@@ -3,7 +3,13 @@ from typing import Iterable, Tuple
 import torch.nn as nn
 
 from ..layer import AdapterLayer
-from ..model_mixin import EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelAdaptersMixin
+from ..model_mixin import (
+    EmbeddingAdaptersMixin,
+    EmbeddingAdaptersWrapperMixin,
+    InvertibleAdaptersMixin,
+    ModelAdaptersMixin,
+    ModelWithHeadsAdaptersMixin,
+)
 
 
 class GPT2DecoderBlockAdaptersMixin:
@@ -20,3 +26,7 @@ class GPT2ModelAdapterMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, Mod
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
         for i, layer in enumerate(self.base_model.h):
             yield i, layer
+
+
+class GPT2ModelWithHeadsAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdaptersMixin):
+    pass

--- a/src/transformers/adapters/mixins/t5.py
+++ b/src/transformers/adapters/mixins/t5.py
@@ -3,7 +3,13 @@ from typing import Iterable, Tuple
 import torch.nn as nn
 
 from ..layer import AdapterLayer
-from ..model_mixin import EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelAdaptersMixin
+from ..model_mixin import (
+    EmbeddingAdaptersMixin,
+    EmbeddingAdaptersWrapperMixin,
+    InvertibleAdaptersMixin,
+    ModelAdaptersMixin,
+    ModelWithHeadsAdaptersMixin,
+)
 
 
 class T5SelfAttentionLayerAdaptersMixin(AdapterLayer):
@@ -45,3 +51,7 @@ class T5ModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, Mode
             self.invertible_adapters_forward = self.encoder.invertible_adapters_forward
             self.delete_invertible_adapter = self.encoder.delete_invertible_adapter
         super()._init_adapter_modules()
+
+
+class T5ModelWithHeadsAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdaptersMixin):
+    pass

--- a/src/transformers/adapters/mixins/t5.py
+++ b/src/transformers/adapters/mixins/t5.py
@@ -5,7 +5,6 @@ import torch.nn as nn
 from ..layer import AdapterLayer
 from ..model_mixin import (
     EmbeddingAdaptersMixin,
-    EmbeddingAdaptersWrapperMixin,
     InvertibleAdaptersMixin,
     ModelAdaptersMixin,
     ModelWithHeadsAdaptersMixin,
@@ -53,5 +52,6 @@ class T5ModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, Mode
         super()._init_adapter_modules()
 
 
-class T5ModelWithHeadsAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdaptersMixin):
+# EmbeddingAdaptersWrapperMixin not required here as base and heads model are identical
+class T5ModelWithHeadsAdaptersMixin(ModelWithHeadsAdaptersMixin):
     pass

--- a/src/transformers/adapters/models/bart/adapter_model.py
+++ b/src/transformers/adapters/models/bart/adapter_model.py
@@ -19,12 +19,13 @@ from ...heads import (
     QuestionAnsweringHead,
     Seq2SeqLMHead,
 )
+from ...model_mixin import EmbeddingAdaptersWrapperMixin
 
 
 @add_start_docstrings(
     "BART Model with the option to add multiple flexible prediction heads on top.", BART_START_DOCSTRING
 )
-class BartAdapterModel(ModelWithFlexibleHeadsAdaptersMixin, BartPretrainedModel):
+class BartAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdaptersMixin, BartPretrainedModel):
     def __init__(self, config: BartConfig, **kwargs):
         super().__init__(config, **kwargs)
         self.model = BartModel(config)

--- a/src/transformers/adapters/models/bert/adapter_model.py
+++ b/src/transformers/adapters/models/bert/adapter_model.py
@@ -14,13 +14,14 @@ from ...heads import (
     QuestionAnsweringHead,
     TaggingHead,
 )
+from ...model_mixin import EmbeddingAdaptersWrapperMixin
 
 
 @add_start_docstrings(
     """Bert Model transformer with the option to add multiple flexible heads on top.""",
     BERT_START_DOCSTRING,
 )
-class BertAdapterModel(ModelWithFlexibleHeadsAdaptersMixin, BertPreTrainedModel):
+class BertAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdaptersMixin, BertPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 

--- a/src/transformers/adapters/models/deberta/adapter_model.py
+++ b/src/transformers/adapters/models/deberta/adapter_model.py
@@ -9,12 +9,13 @@ from ...heads import (
     QuestionAnsweringHead,
     TaggingHead,
 )
+from ...model_mixin import EmbeddingAdaptersWrapperMixin
 
 
 @add_start_docstrings(
     """Deberta Model transformer with the option to add multiple flexible heads on top.""",
 )
-class DebertaAdapterModel(ModelWithFlexibleHeadsAdaptersMixin, DebertaPreTrainedModel):
+class DebertaAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdaptersMixin, DebertaPreTrainedModel):
     _keys_to_ignore_on_load_unexpected = [r"cls.predictions.bias"]
 
     def __init__(self, config):

--- a/src/transformers/adapters/models/debertaV2/adapter_model.py
+++ b/src/transformers/adapters/models/debertaV2/adapter_model.py
@@ -10,12 +10,15 @@ from ...heads import (
     QuestionAnsweringHead,
     TaggingHead,
 )
+from ...model_mixin import EmbeddingAdaptersWrapperMixin
 
 
 @add_start_docstrings(
     """Deberta v2 Model transformer with the option to add multiple flexible heads on top.""",
 )
-class DebertaV2AdapterModel(ModelWithFlexibleHeadsAdaptersMixin, DebertaV2PreTrainedModel):
+class DebertaV2AdapterModel(
+    EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdaptersMixin, DebertaV2PreTrainedModel
+):
     _keys_to_ignore_on_load_unexpected = [r"cls.predictions.bias"]
 
     def __init__(self, config):

--- a/src/transformers/adapters/models/distilbert/adapter_model.py
+++ b/src/transformers/adapters/models/distilbert/adapter_model.py
@@ -20,13 +20,16 @@ from ...heads import (
     QuestionAnsweringHead,
     TaggingHead,
 )
+from ...model_mixin import EmbeddingAdaptersWrapperMixin
 
 
 @add_start_docstrings(
     """DistilBert Model transformer with the option to add multiple flexible heads on top.""",
     DISTILBERT_START_DOCSTRING,
 )
-class DistilBertAdapterModel(ModelWithFlexibleHeadsAdaptersMixin, DistilBertPreTrainedModel):
+class DistilBertAdapterModel(
+    EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdaptersMixin, DistilBertPreTrainedModel
+):
     def __init__(self, config):
         super().__init__(config)
         self.distilbert = DistilBertModel(config)

--- a/src/transformers/adapters/models/gpt2/adapter_model.py
+++ b/src/transformers/adapters/models/gpt2/adapter_model.py
@@ -13,6 +13,7 @@ from ...heads import (
     MultiLabelClassificationHead,
     TaggingHead,
 )
+from ...model_mixin import EmbeddingAdaptersWrapperMixin
 
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ it cannot guess the padding tokens when :obj:`inputs_embeds` are passed instead 
 """,
     GPT2_START_DOCSTRING,
 )
-class GPT2AdapterModel(ModelWithFlexibleHeadsAdaptersMixin, GPT2PreTrainedModel):
+class GPT2AdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdaptersMixin, GPT2PreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.transformer = GPT2Model(config)

--- a/src/transformers/adapters/models/mbart/adapter_model.py
+++ b/src/transformers/adapters/models/mbart/adapter_model.py
@@ -19,12 +19,13 @@ from ...heads import (
     QuestionAnsweringHead,
     Seq2SeqLMHead,
 )
+from ...model_mixin import EmbeddingAdaptersWrapperMixin
 
 
 @add_start_docstrings(
     "MBART Model with the option to add multiple flexible prediction heads on top.", MBART_START_DOCSTRING
 )
-class MBartAdapterModel(ModelWithFlexibleHeadsAdaptersMixin, MBartPreTrainedModel):
+class MBartAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdaptersMixin, MBartPreTrainedModel):
     def __init__(self, config: MBartConfig, **kwargs):
         super().__init__(config, **kwargs)
         self.model = MBartModel(config)

--- a/src/transformers/adapters/models/roberta/adapter_model.py
+++ b/src/transformers/adapters/models/roberta/adapter_model.py
@@ -19,13 +19,14 @@ from ...heads import (
     QuestionAnsweringHead,
     TaggingHead,
 )
+from ...model_mixin import EmbeddingAdaptersWrapperMixin
 
 
 @add_start_docstrings(
     """Roberta Model transformer with the option to add multiple flexible heads on top.""",
     ROBERTA_START_DOCSTRING,
 )
-class RobertaAdapterModel(ModelWithFlexibleHeadsAdaptersMixin, RobertaPreTrainedModel):
+class RobertaAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdaptersMixin, RobertaPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 

--- a/src/transformers/adapters/models/t5/adapter_model.py
+++ b/src/transformers/adapters/models/t5/adapter_model.py
@@ -6,13 +6,14 @@ import torch
 from ....models.t5.modeling_t5 import T5_INPUTS_DOCSTRING, T5_START_DOCSTRING, T5Model, T5PreTrainedModel
 from ....utils import add_start_docstrings, add_start_docstrings_to_model_forward
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin, Seq2SeqLMHead
+from ...model_mixin import EmbeddingAdaptersWrapperMixin
 
 
 logger = logging.getLogger(__name__)
 
 
 @add_start_docstrings("T5 Model with the option to add multiple flexible prediction heads on top.", T5_START_DOCSTRING)
-class T5AdapterModel(ModelWithFlexibleHeadsAdaptersMixin, T5PreTrainedModel):
+class T5AdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdaptersMixin, T5PreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 

--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -32,8 +32,9 @@ from ...adapters.mixins.bart import (
     BartDecoderLayerAdaptersMixin,
     BartEncoderLayerAdaptersMixin,
     BartModelAdaptersMixin,
+    BartModelWithHeadsAdaptersMixin,
 )
-from ...adapters.model_mixin import InvertibleAdaptersMixin, ModelWithHeadsAdaptersMixin
+from ...adapters.model_mixin import InvertibleAdaptersMixin
 from ...adapters.prefix_tuning import PrefixTuningShim
 from ...modeling_outputs import (
     BaseModelOutput,
@@ -1302,7 +1303,7 @@ class BartModel(BartModelAdaptersMixin, BartPretrainedModel):
 @add_start_docstrings(
     "The BART Model with a language modeling head. Can be used for summarization.", BART_START_DOCSTRING
 )
-class BartForConditionalGeneration(ModelWithHeadsAdaptersMixin, BartPretrainedModel):
+class BartForConditionalGeneration(BartModelWithHeadsAdaptersMixin, BartPretrainedModel):
     base_model_prefix = "model"
     _keys_to_ignore_on_load_missing = [r"final_logits_bias", r"lm_head\.weight"]
 
@@ -1472,7 +1473,7 @@ class BartForConditionalGeneration(ModelWithHeadsAdaptersMixin, BartPretrainedMo
     """,
     BART_START_DOCSTRING,
 )
-class BartForSequenceClassification(ModelWithHeadsAdaptersMixin, BartPretrainedModel):
+class BartForSequenceClassification(BartModelWithHeadsAdaptersMixin, BartPretrainedModel):
     def __init__(self, config: BartConfig, **kwargs):
         super().__init__(config, **kwargs)
         self.model = BartModel(config)
@@ -1600,7 +1601,7 @@ class BartForSequenceClassification(ModelWithHeadsAdaptersMixin, BartPretrainedM
     """,
     BART_START_DOCSTRING,
 )
-class BartForQuestionAnswering(ModelWithHeadsAdaptersMixin, BartPretrainedModel):
+class BartForQuestionAnswering(BartModelWithHeadsAdaptersMixin, BartPretrainedModel):
     def __init__(self, config):
         super().__init__(config)
 
@@ -1737,7 +1738,7 @@ class BartDecoderWrapper(BartModelAdaptersMixin, BartPretrainedModel):
         return self.decoder.get_input_embeddings()
 
 
-class BartForCausalLM(ModelWithHeadsAdaptersMixin, BartPretrainedModel):
+class BartForCausalLM(BartModelWithHeadsAdaptersMixin, BartPretrainedModel):
     def __init__(self, config):
         super().__init__(config)
         decoder_config = copy.deepcopy(config)

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -32,8 +32,12 @@ from ...activations import ACT2FN
 from ...adapters.composition import adjust_tensors_for_parallel
 from ...adapters.context import ForwardContext
 from ...adapters.lora import Linear as LoRALinear
-from ...adapters.mixins.bert import BertModelAdaptersMixin, BertOutputAdaptersMixin, BertSelfOutputAdaptersMixin
-from ...adapters.model_mixin import ModelWithHeadsAdaptersMixin
+from ...adapters.mixins.bert import (
+    BertModelAdaptersMixin,
+    BertModelWithHeadsAdaptersMixin,
+    BertOutputAdaptersMixin,
+    BertSelfOutputAdaptersMixin,
+)
 from ...adapters.prefix_tuning import PrefixTuningShim
 from ...modeling_outputs import (
     BaseModelOutputWithPastAndCrossAttentions,
@@ -1076,7 +1080,7 @@ class BertModel(BertModelAdaptersMixin, BertPreTrainedModel):
     """,
     BERT_START_DOCSTRING,
 )
-class BertForPreTraining(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
+class BertForPreTraining(BertModelWithHeadsAdaptersMixin, BertPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 
@@ -1184,7 +1188,7 @@ class BertForPreTraining(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
 @add_start_docstrings(
     """Bert Model with a `language modeling` head on top for CLM fine-tuning.""", BERT_START_DOCSTRING
 )
-class BertLMHeadModel(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
+class BertLMHeadModel(BertModelWithHeadsAdaptersMixin, BertPreTrainedModel):
 
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
     _keys_to_ignore_on_load_missing = [r"position_ids", r"predictions.decoder.bias"]
@@ -1322,7 +1326,7 @@ class BertLMHeadModel(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
 
 
 @add_start_docstrings("""Bert Model with a `language modeling` head on top.""", BERT_START_DOCSTRING)
-class BertForMaskedLM(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
+class BertForMaskedLM(BertModelWithHeadsAdaptersMixin, BertPreTrainedModel):
 
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
     _keys_to_ignore_on_load_missing = [r"position_ids", r"predictions.decoder.bias"]
@@ -1438,7 +1442,7 @@ class BertForMaskedLM(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
     """Bert Model with a `next sentence prediction (classification)` head on top.""",
     BERT_START_DOCSTRING,
 )
-class BertForNextSentencePrediction(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
+class BertForNextSentencePrediction(BertModelWithHeadsAdaptersMixin, BertPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 
@@ -1542,7 +1546,7 @@ class BertForNextSentencePrediction(ModelWithHeadsAdaptersMixin, BertPreTrainedM
     """,
     BERT_START_DOCSTRING,
 )
-class BertForSequenceClassification(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
+class BertForSequenceClassification(BertModelWithHeadsAdaptersMixin, BertPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.num_labels = config.num_labels
@@ -1646,7 +1650,7 @@ class BertForSequenceClassification(ModelWithHeadsAdaptersMixin, BertPreTrainedM
     """,
     BERT_START_DOCSTRING,
 )
-class BertForMultipleChoice(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
+class BertForMultipleChoice(BertModelWithHeadsAdaptersMixin, BertPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 
@@ -1741,7 +1745,7 @@ class BertForMultipleChoice(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
     """,
     BERT_START_DOCSTRING,
 )
-class BertForTokenClassification(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
+class BertForTokenClassification(BertModelWithHeadsAdaptersMixin, BertPreTrainedModel):
 
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
 
@@ -1828,7 +1832,7 @@ class BertForTokenClassification(ModelWithHeadsAdaptersMixin, BertPreTrainedMode
     """,
     BERT_START_DOCSTRING,
 )
-class BertForQuestionAnswering(ModelWithHeadsAdaptersMixin, BertPreTrainedModel):
+class BertForQuestionAnswering(BertModelWithHeadsAdaptersMixin, BertPreTrainedModel):
 
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
 

--- a/src/transformers/models/deberta/modeling_deberta.py
+++ b/src/transformers/models/deberta/modeling_deberta.py
@@ -27,8 +27,12 @@ from ...adapters.composition import adjust_tensors_for_parallel
 from ...adapters.context import ForwardContext
 from ...adapters.lora import Linear as LoRALinear
 from ...adapters.lora import MergedLinear as LoRAMergedLinear
-from ...adapters.mixins.bert import BertModelAdaptersMixin, BertOutputAdaptersMixin, BertSelfOutputAdaptersMixin
-from ...adapters.model_mixin import ModelWithHeadsAdaptersMixin
+from ...adapters.mixins.bert import (
+    BertModelAdaptersMixin,
+    BertModelWithHeadsAdaptersMixin,
+    BertOutputAdaptersMixin,
+    BertSelfOutputAdaptersMixin,
+)
 from ...adapters.prefix_tuning import PrefixTuningShim
 from ...modeling_outputs import (
     BaseModelOutput,
@@ -1017,7 +1021,7 @@ class DebertaModel(BertModelAdaptersMixin, DebertaPreTrainedModel):
 
 
 @add_start_docstrings("""DeBERTa Model with a `language modeling` head on top.""", DEBERTA_START_DOCSTRING)
-class DebertaForMaskedLM(ModelWithHeadsAdaptersMixin, DebertaPreTrainedModel):
+class DebertaForMaskedLM(BertModelWithHeadsAdaptersMixin, DebertaPreTrainedModel):
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
     _keys_to_ignore_on_load_missing = [r"position_ids", r"predictions.decoder.bias"]
 
@@ -1165,7 +1169,7 @@ class DebertaOnlyMLMHead(nn.Module):
     """,
     DEBERTA_START_DOCSTRING,
 )
-class DebertaForSequenceClassification(ModelWithHeadsAdaptersMixin, DebertaPreTrainedModel):
+class DebertaForSequenceClassification(BertModelWithHeadsAdaptersMixin, DebertaPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 
@@ -1284,7 +1288,7 @@ class DebertaForSequenceClassification(ModelWithHeadsAdaptersMixin, DebertaPreTr
     """,
     DEBERTA_START_DOCSTRING,
 )
-class DebertaForTokenClassification(ModelWithHeadsAdaptersMixin, DebertaPreTrainedModel):
+class DebertaForTokenClassification(BertModelWithHeadsAdaptersMixin, DebertaPreTrainedModel):
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
 
     def __init__(self, config):
@@ -1360,7 +1364,7 @@ class DebertaForTokenClassification(ModelWithHeadsAdaptersMixin, DebertaPreTrain
     """,
     DEBERTA_START_DOCSTRING,
 )
-class DebertaForQuestionAnswering(ModelWithHeadsAdaptersMixin, DebertaPreTrainedModel):
+class DebertaForQuestionAnswering(BertModelWithHeadsAdaptersMixin, DebertaPreTrainedModel):
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
 
     def __init__(self, config):

--- a/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
@@ -27,8 +27,12 @@ from ...activations import ACT2FN
 from ...adapters.composition import adjust_tensors_for_parallel
 from ...adapters.context import ForwardContext
 from ...adapters.lora import Linear as LoRALinear
-from ...adapters.mixins.bert import BertModelAdaptersMixin, BertOutputAdaptersMixin, BertSelfOutputAdaptersMixin
-from ...adapters.model_mixin import ModelWithHeadsAdaptersMixin
+from ...adapters.mixins.bert import (
+    BertModelAdaptersMixin,
+    BertModelWithHeadsAdaptersMixin,
+    BertOutputAdaptersMixin,
+    BertSelfOutputAdaptersMixin,
+)
 from ...adapters.prefix_tuning import PrefixTuningShim
 from ...modeling_outputs import (
     BaseModelOutput,
@@ -1115,7 +1119,7 @@ class DebertaV2Model(BertModelAdaptersMixin, DebertaV2PreTrainedModel):
 
 @add_start_docstrings("""DeBERTa Model with a `language modeling` head on top.""", DEBERTA_START_DOCSTRING)
 # Copied from transformers.models.deberta.modeling_deberta.DebertaForMaskedLM with Deberta->DebertaV2
-class DebertaV2ForMaskedLM(ModelWithHeadsAdaptersMixin, DebertaV2PreTrainedModel):
+class DebertaV2ForMaskedLM(BertModelWithHeadsAdaptersMixin, DebertaV2PreTrainedModel):
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
     _keys_to_ignore_on_load_missing = [r"position_ids", r"predictions.decoder.bias"]
 
@@ -1265,7 +1269,7 @@ class DebertaV2OnlyMLMHead(nn.Module):
     DEBERTA_START_DOCSTRING,
 )
 # Copied from transformers.models.deberta.modeling_deberta.DebertaForSequenceClassification with Deberta->DebertaV2
-class DebertaV2ForSequenceClassification(ModelWithHeadsAdaptersMixin, DebertaV2PreTrainedModel):
+class DebertaV2ForSequenceClassification(BertModelWithHeadsAdaptersMixin, DebertaV2PreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 
@@ -1385,7 +1389,7 @@ class DebertaV2ForSequenceClassification(ModelWithHeadsAdaptersMixin, DebertaV2P
     DEBERTA_START_DOCSTRING,
 )
 # Copied from transformers.models.deberta.modeling_deberta.DebertaForTokenClassification with Deberta->DebertaV2
-class DebertaV2ForTokenClassification(ModelWithHeadsAdaptersMixin, DebertaV2PreTrainedModel):
+class DebertaV2ForTokenClassification(BertModelWithHeadsAdaptersMixin, DebertaV2PreTrainedModel):
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
 
     def __init__(self, config):
@@ -1462,7 +1466,7 @@ class DebertaV2ForTokenClassification(ModelWithHeadsAdaptersMixin, DebertaV2PreT
     DEBERTA_START_DOCSTRING,
 )
 # Copied from transformers.models.deberta.modeling_deberta.DebertaForQuestionAnswering with Deberta->DebertaV2
-class DebertaV2ForQuestionAnswering(ModelWithHeadsAdaptersMixin, DebertaV2PreTrainedModel):
+class DebertaV2ForQuestionAnswering(BertModelWithHeadsAdaptersMixin, DebertaV2PreTrainedModel):
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
 
     def __init__(self, config):
@@ -1562,7 +1566,7 @@ class DebertaV2ForQuestionAnswering(ModelWithHeadsAdaptersMixin, DebertaV2PreTra
     """,
     DEBERTA_START_DOCSTRING,
 )
-class DebertaV2ForMultipleChoice(ModelWithHeadsAdaptersMixin, DebertaV2PreTrainedModel):
+class DebertaV2ForMultipleChoice(BertModelWithHeadsAdaptersMixin, DebertaV2PreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 

--- a/src/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_distilbert.py
@@ -33,8 +33,11 @@ from ...activations import get_activation
 from ...adapters.composition import adjust_tensors_for_parallel
 from ...adapters.context import ForwardContext
 from ...adapters.lora import Linear as LoRALinear
-from ...adapters.mixins.distilbert import DistilBertModelAdaptersMixin, DistilBertTransfomerBlockAdaptersMixin
-from ...adapters.model_mixin import ModelWithHeadsAdaptersMixin
+from ...adapters.mixins.distilbert import (
+    DistilBertModelAdaptersMixin,
+    DistilBertModelWithHeadsAdaptersMixin,
+    DistilBertTransfomerBlockAdaptersMixin,
+)
 from ...adapters.prefix_tuning import PrefixTuningShim
 from ...deepspeed import is_deepspeed_zero3_enabled
 from ...modeling_outputs import (
@@ -597,7 +600,7 @@ class DistilBertModel(DistilBertModelAdaptersMixin, DistilBertPreTrainedModel):
     """DistilBert Model with a `masked language modeling` head on top.""",
     DISTILBERT_START_DOCSTRING,
 )
-class DistilBertForMaskedLM(ModelWithHeadsAdaptersMixin, DistilBertPreTrainedModel):
+class DistilBertForMaskedLM(DistilBertModelWithHeadsAdaptersMixin, DistilBertPreTrainedModel):
     def __init__(self, config: PretrainedConfig):
         super().__init__(config)
 
@@ -704,7 +707,7 @@ class DistilBertForMaskedLM(ModelWithHeadsAdaptersMixin, DistilBertPreTrainedMod
     """,
     DISTILBERT_START_DOCSTRING,
 )
-class DistilBertForSequenceClassification(ModelWithHeadsAdaptersMixin, DistilBertPreTrainedModel):
+class DistilBertForSequenceClassification(DistilBertModelWithHeadsAdaptersMixin, DistilBertPreTrainedModel):
     def __init__(self, config: PretrainedConfig):
         super().__init__(config)
         self.num_labels = config.num_labels
@@ -822,7 +825,7 @@ class DistilBertForSequenceClassification(ModelWithHeadsAdaptersMixin, DistilBer
     """,
     DISTILBERT_START_DOCSTRING,
 )
-class DistilBertForQuestionAnswering(ModelWithHeadsAdaptersMixin, DistilBertPreTrainedModel):
+class DistilBertForQuestionAnswering(DistilBertModelWithHeadsAdaptersMixin, DistilBertPreTrainedModel):
     def __init__(self, config: PretrainedConfig):
         super().__init__(config)
 
@@ -939,7 +942,7 @@ class DistilBertForQuestionAnswering(ModelWithHeadsAdaptersMixin, DistilBertPreT
     """,
     DISTILBERT_START_DOCSTRING,
 )
-class DistilBertForTokenClassification(ModelWithHeadsAdaptersMixin, DistilBertPreTrainedModel):
+class DistilBertForTokenClassification(DistilBertModelWithHeadsAdaptersMixin, DistilBertPreTrainedModel):
     def __init__(self, config: PretrainedConfig):
         super().__init__(config)
         self.num_labels = config.num_labels
@@ -1034,7 +1037,7 @@ class DistilBertForTokenClassification(ModelWithHeadsAdaptersMixin, DistilBertPr
     """,
     DISTILBERT_START_DOCSTRING,
 )
-class DistilBertForMultipleChoice(ModelWithHeadsAdaptersMixin, DistilBertPreTrainedModel):
+class DistilBertForMultipleChoice(DistilBertModelWithHeadsAdaptersMixin, DistilBertPreTrainedModel):
     def __init__(self, config: PretrainedConfig):
         super().__init__(config)
 

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -38,8 +38,11 @@ from ...adapters.composition import adjust_tensors_for_parallel
 from ...adapters.context import ForwardContext
 from ...adapters.lora import Linear as LoRALinear
 from ...adapters.lora import MergedLinear as LoRAMergedLinear
-from ...adapters.mixins.gpt2 import GPT2DecoderBlockAdaptersMixin, GPT2ModelAdapterMixin
-from ...adapters.model_mixin import ModelWithHeadsAdaptersMixin
+from ...adapters.mixins.gpt2 import (
+    GPT2DecoderBlockAdaptersMixin,
+    GPT2ModelAdapterMixin,
+    GPT2ModelWithHeadsAdaptersMixin,
+)
 from ...adapters.prefix_tuning import PrefixTuningShim
 from ...modeling_outputs import (
     BaseModelOutputWithPastAndCrossAttentions,
@@ -972,7 +975,7 @@ class GPT2Model(GPT2ModelAdapterMixin, GPT2PreTrainedModel):
     """,
     GPT2_START_DOCSTRING,
 )
-class GPT2LMHeadModel(ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
+class GPT2LMHeadModel(GPT2ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
     _keys_to_ignore_on_load_missing = [r"attn.masked_bias", r"attn.bias", r"lm_head.weight"]
 
     def __init__(self, config):
@@ -1143,7 +1146,7 @@ input sequence).
 """,
     GPT2_START_DOCSTRING,
 )
-class GPT2DoubleHeadsModel(ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
+class GPT2DoubleHeadsModel(GPT2ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
     _keys_to_ignore_on_load_missing = [r"attn.masked_bias", r"attn.bias", r"lm_head.weight"]
 
     def __init__(self, config):
@@ -1357,7 +1360,7 @@ class GPT2DoubleHeadsModel(ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
     """,
     GPT2_START_DOCSTRING,
 )
-class GPT2ForSequenceClassification(ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
+class GPT2ForSequenceClassification(GPT2ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
     _keys_to_ignore_on_load_missing = [r"h\.\d+\.attn\.masked_bias", r"lm_head\.weight"]
 
     def __init__(self, config):
@@ -1485,7 +1488,7 @@ class GPT2ForSequenceClassification(ModelWithHeadsAdaptersMixin, GPT2PreTrainedM
     """,
     GPT2_START_DOCSTRING,
 )
-class GPT2ForTokenClassification(ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
+class GPT2ForTokenClassification(GPT2ModelWithHeadsAdaptersMixin, GPT2PreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.num_labels = config.num_labels

--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -31,8 +31,9 @@ from ...adapters.mixins.bart import (
     BartDecoderLayerAdaptersMixin,
     BartEncoderLayerAdaptersMixin,
     BartModelAdaptersMixin,
+    BartModelWithHeadsAdaptersMixin,
 )
-from ...adapters.model_mixin import InvertibleAdaptersMixin, ModelWithHeadsAdaptersMixin
+from ...adapters.model_mixin import InvertibleAdaptersMixin
 from ...adapters.prefix_tuning import PrefixTuningShim
 from ...modeling_outputs import (
     BaseModelOutput,
@@ -1296,7 +1297,7 @@ class MBartModel(BartModelAdaptersMixin, MBartPreTrainedModel):
 @add_start_docstrings(
     "The MBART Model with a language modeling head. Can be used for summarization.", MBART_START_DOCSTRING
 )
-class MBartForConditionalGeneration(ModelWithHeadsAdaptersMixin, MBartPreTrainedModel):
+class MBartForConditionalGeneration(BartModelWithHeadsAdaptersMixin, MBartPreTrainedModel):
     base_model_prefix = "model"
     _keys_to_ignore_on_load_missing = [
         r"final_logits_bias",
@@ -1470,7 +1471,7 @@ class MBartForConditionalGeneration(ModelWithHeadsAdaptersMixin, MBartPreTrained
     """,
     MBART_START_DOCSTRING,
 )
-class MBartForSequenceClassification(ModelWithHeadsAdaptersMixin, MBartPreTrainedModel):
+class MBartForSequenceClassification(BartModelWithHeadsAdaptersMixin, MBartPreTrainedModel):
     def __init__(self, config: MBartConfig, **kwargs):
         super().__init__(config, **kwargs)
         self.model = MBartModel(config)
@@ -1599,7 +1600,7 @@ class MBartForSequenceClassification(ModelWithHeadsAdaptersMixin, MBartPreTraine
     """,
     MBART_START_DOCSTRING,
 )
-class MBartForQuestionAnswering(ModelWithHeadsAdaptersMixin, MBartPreTrainedModel):
+class MBartForQuestionAnswering(BartModelWithHeadsAdaptersMixin, MBartPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 
@@ -1739,7 +1740,7 @@ class MBartDecoderWrapper(BartModelAdaptersMixin, MBartPreTrainedModel):
 
 
 # Copied from transformers.models.bart.modeling_bart.BartForCausalLM with Bart->MBart, facebook/bart-base->facebook/mbart-large-cc25
-class MBartForCausalLM(ModelWithHeadsAdaptersMixin, MBartPreTrainedModel):
+class MBartForCausalLM(BartModelWithHeadsAdaptersMixin, MBartPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         decoder_config = copy.deepcopy(config)

--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -28,8 +28,12 @@ from ...activations import ACT2FN, gelu
 from ...adapters.composition import adjust_tensors_for_parallel
 from ...adapters.context import ForwardContext
 from ...adapters.lora import Linear as LoRALinear
-from ...adapters.mixins.bert import BertModelAdaptersMixin, BertOutputAdaptersMixin, BertSelfOutputAdaptersMixin
-from ...adapters.model_mixin import ModelWithHeadsAdaptersMixin
+from ...adapters.mixins.bert import (
+    BertModelAdaptersMixin,
+    BertModelWithHeadsAdaptersMixin,
+    BertOutputAdaptersMixin,
+    BertSelfOutputAdaptersMixin,
+)
 from ...adapters.prefix_tuning import PrefixTuningShim
 from ...modeling_outputs import (
     BaseModelOutputWithPastAndCrossAttentions,
@@ -900,7 +904,7 @@ class RobertaModel(BertModelAdaptersMixin, RobertaPreTrainedModel):
 @add_start_docstrings(
     """RoBERTa Model with a `language modeling` head on top for CLM fine-tuning.""", ROBERTA_START_DOCSTRING
 )
-class RobertaForCausalLM(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
+class RobertaForCausalLM(BertModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
     _keys_to_ignore_on_save = [r"lm_head.decoder.weight", r"lm_head.decoder.bias"]
     _keys_to_ignore_on_load_missing = [r"position_ids", r"lm_head.decoder.weight", r"lm_head.decoder.bias"]
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
@@ -1055,7 +1059,7 @@ class RobertaForCausalLM(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
 
 
 @add_start_docstrings("""RoBERTa Model with a `language modeling` head on top.""", ROBERTA_START_DOCSTRING)
-class RobertaForMaskedLM(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
+class RobertaForMaskedLM(BertModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
     _keys_to_ignore_on_save = [r"lm_head.decoder.weight", r"lm_head.decoder.bias"]
     _keys_to_ignore_on_load_missing = [r"position_ids", r"lm_head.decoder.weight", r"lm_head.decoder.bias"]
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
@@ -1192,7 +1196,7 @@ class RobertaLMHead(nn.Module):
     """,
     ROBERTA_START_DOCSTRING,
 )
-class RobertaForSequenceClassification(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
+class RobertaForSequenceClassification(BertModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
     _keys_to_ignore_on_load_missing = [r"position_ids"]
 
     def __init__(self, config):
@@ -1292,7 +1296,7 @@ class RobertaForSequenceClassification(ModelWithHeadsAdaptersMixin, RobertaPreTr
     """,
     ROBERTA_START_DOCSTRING,
 )
-class RobertaForMultipleChoice(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
+class RobertaForMultipleChoice(BertModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
     _keys_to_ignore_on_load_missing = [r"position_ids"]
 
     def __init__(self, config):
@@ -1385,7 +1389,7 @@ class RobertaForMultipleChoice(ModelWithHeadsAdaptersMixin, RobertaPreTrainedMod
     """,
     ROBERTA_START_DOCSTRING,
 )
-class RobertaForTokenClassification(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
+class RobertaForTokenClassification(BertModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
     _keys_to_ignore_on_load_missing = [r"position_ids"]
 
@@ -1494,7 +1498,7 @@ class RobertaClassificationHead(nn.Module):
     """,
     ROBERTA_START_DOCSTRING,
 )
-class RobertaForQuestionAnswering(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
+class RobertaForQuestionAnswering(BertModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
     _keys_to_ignore_on_load_missing = [r"position_ids"]
 

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -34,9 +34,10 @@ from ...adapters.mixins.t5 import (
     T5CrossAttentionLayerAdaptersMixin,
     T5FFLayerAdaptersMixin,
     T5ModelAdaptersMixin,
+    T5ModelWithHeadsAdaptersMixin,
     T5SelfAttentionLayerAdaptersMixin,
 )
-from ...adapters.model_mixin import InvertibleAdaptersMixin, ModelWithHeadsAdaptersMixin
+from ...adapters.model_mixin import InvertibleAdaptersMixin
 from ...adapters.prefix_tuning import PrefixTuningShim
 from ...modeling_outputs import (
     BaseModelOutput,
@@ -1507,7 +1508,7 @@ class T5Model(T5ModelAdaptersMixin, T5PreTrainedModel):
 
 
 @add_start_docstrings("""T5 Model with a `language modeling` head on top.""", T5_START_DOCSTRING)
-class T5ForConditionalGeneration(ModelWithHeadsAdaptersMixin, T5ModelAdaptersMixin, T5PreTrainedModel):
+class T5ForConditionalGeneration(T5ModelWithHeadsAdaptersMixin, T5ModelAdaptersMixin, T5PreTrainedModel):
     _keys_to_ignore_on_load_missing = [
         r"encoder\.embed_tokens\.weight",
         r"decoder\.embed_tokens\.weight",

--- a/tests_adapters/test_adapter_embeddings.py
+++ b/tests_adapters/test_adapter_embeddings.py
@@ -160,3 +160,7 @@ class EmbeddingTestMixin:
         test = test_embedding(input_test)
 
         self.assertTrue(torch.equal(default, test))
+
+        # activate for training
+        model.add_adapter("test")
+        model.train_adapter("test", train_embeddings=True)

--- a/tests_adapters/test_adapter_embeddings.py
+++ b/tests_adapters/test_adapter_embeddings.py
@@ -27,6 +27,14 @@ class EmbeddingTestMixin:
         model.add_embeddings("test", tokenizer)
         self.assertEqual(model.active_embeddings, "test")
 
+    def test_add_embedding_tokens(self):
+        model = self.get_model()
+        tokenizer = AutoTokenizer.from_pretrained("tests_adapters/fixtures/SiBERT")
+        self.assertEqual(tokenizer.vocab_size, 10000)
+        tokenizer.add_tokens(["test_token"])
+        model.add_embeddings("test", tokenizer)
+        self.assertEqual(model.get_input_embeddings().num_embeddings, 10001)
+
     def test_delete_embeddings(self):
         model = self.get_model()
         tokenizer = AutoTokenizer.from_pretrained("tests_adapters/fixtures/SiBERT")
@@ -73,7 +81,12 @@ class EmbeddingTestMixin:
         self.assertTrue(torch.equal(output1[0], output2[0]))
 
     def test_training_embedding(self):
+        tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name, use_fast=False)
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
         model = AutoAdapterModel.from_config(self.config())
+        model.add_embeddings("test", tokenizer)
+        self.assertEqual(model.active_embeddings, "test")
         model.add_adapter("test")
         self.add_head(model, "test")
         model.train_adapter("test", train_embeddings=True)
@@ -85,7 +98,7 @@ class EmbeddingTestMixin:
 
         state_dict_pre = copy.deepcopy(model.state_dict())
 
-        train_dataset = self.dataset()
+        train_dataset = self.dataset(tokenizer=tokenizer)
         training_args = TrainingArguments(
             output_dir="./examples",
             do_train=True,


### PR DESCRIPTION
- Introduces a new `EmbeddingAdaptersWrapperMixin` to make embedding methods available to heads model classes. This is implemented in new per-model heads mixins. Closes #382.
- Fixes size issues with embeddings. Closes #383.
- Detach embedding weights before cloning. Closes #384.