### PR TITLE
Return AdapterFusion attentions using `output_adapter_fusion_attentions` argument

### DIFF
--- a/adapter_docs/adapter_composition.md
+++ b/adapter_docs/adapter_composition.md
@@ -109,6 +109,32 @@ To learn how training an _AdapterFusion_ layer works, check out [this Colab note
 In v1.x of `adapter-transformers`, fusing adapters was done using a nested list of adapter names, i.e. the example from above would be defined as `[["d", "e", "f"]]`.
 For backwards compatibility, you can still do this, although it is recommended to use the new syntax.
 
+#### Retrieving AdapterFusion attentions
+
+Finally, it is possible to retrieve the attention scores computed by each fusion layer in a forward pass of the model.
+These scores can be used for analyzing the fused adapter blocks and can serve as the basis for visualizations similar to those in the AdapterFusion paper.
+You can collect the fusion attention scores by passing `output_adapter_fusion_attentions=True` to the model forward call.
+The scores for each layer will then be saved in the `adapter_fusion_attentions` attribute of the output:
+
+```python
+outputs = model(**inputs, output_adapter_fusion_attentions=True)
+attention_scores = outputs.adapter_fusion_attentions
+```
+Note that this parameter is only available to base model classes and [AdapterModel classes](prediction_heads.md#adaptermodel-classes).
+In the example, `attention_scores` holds a dictionary of the following form:
+```
+{
+    '<fusion_name>': {
+        <layer_id>: {
+            '<module_location>': np.array([...]),
+            ...
+        },
+        ...
+    },
+    ...
+}
+```
+
 ## `Split`
 
 ```{eval-rst}

--- a/src/transformers/adapters/context.py
+++ b/src/transformers/adapters/context.py
@@ -78,7 +78,7 @@ class ForwardContext:
     # thread-local storage that holds a stack of active contexts
     storage = threading.local()
 
-    context_attributes = ["adapter_gating_scores"]
+    context_attributes = ["adapter_gating_scores", "adapter_fusion_attentions"]
 
     def __init__(self, model, *args, **kwargs):
         # If the model has a method ``forward_context()``, use it to create the context.

--- a/src/transformers/adapters/layer.py
+++ b/src/transformers/adapters/layer.py
@@ -248,6 +248,8 @@ class AdapterLayer(AdapterLayerBase, nn.Module):
         """
         Performs adapter fusion with the given adapters for the given input.
         """
+        context = ForwardContext.get_context()
+
         # config of _last_ fused adapter is significant
         fusion_config = self.config.adapters.get_fusion(adapter_setup.name)
         last_adapter = self.adapters[adapter_setup.last()]
@@ -266,7 +268,6 @@ class AdapterLayer(AdapterLayerBase, nn.Module):
             # Case 2: We have a single adapter which is part of this module -> forward pass
             elif adapter_block in self.adapters:
                 adapter_layer = self.adapters[adapter_block]
-                context = ForwardContext.get_context()
                 layer_output = adapter_layer(
                     hidden_states, residual_input=residual, output_gating=context.output_adapter_gating_scores
                 )

--- a/src/transformers/adapters/layer.py
+++ b/src/transformers/adapters/layer.py
@@ -61,6 +61,14 @@ class AdapterLayerBase(ABC):
             else:
                 gating_cache[adapter_name][self.layer_idx][self.location_key] = gating_score
 
+    def _store_fusion_attentions(self, fusion_name, attentions):
+        context = ForwardContext.get_context()
+        if context.output_adapter_fusion_attentions:
+            attention_cache = context.adapter_fusion_attentions
+            if self.layer_idx not in attention_cache[fusion_name]:
+                attention_cache[fusion_name][self.layer_idx] = {}
+            attention_cache[fusion_name][self.layer_idx][self.location_key] = attentions
+
     @abstractmethod
     def add_adapter(self, adapter_name: str, layer_idx: int):
         raise NotImplementedError()
@@ -278,12 +286,18 @@ class AdapterLayer(AdapterLayerBase, nn.Module):
             up_list = torch.stack(up_list)
             up_list = up_list.permute(1, 2, 0, 3)
 
-            hidden_states = self.adapter_fusion_layer[adapter_setup.name](
+            fusion_output = self.adapter_fusion_layer[adapter_setup.name](
                 query,
                 up_list,
                 up_list,
                 residual,
+                output_attentions=context.output_adapter_fusion_attentions,
             )
+            if context.output_adapter_fusion_attentions:
+                hidden_states = fusion_output[0]
+                self._store_fusion_attentions(adapter_setup.name, fusion_output[-1])
+            else:
+                hidden_states = fusion_output
 
         return hidden_states
 

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -787,7 +787,9 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
         context.prefix_states = self.base_model.prefix_tuning(*args, **kwargs)
         # Adapter gating and attention outputs
         context.output_adapter_gating_scores = kwargs.get("output_adapter_gating_scores", False)
+        context.output_adapter_fusion_attentions = kwargs.get("output_adapter_fusion_attentions", False)
         context.adapter_gating_scores = defaultdict(dict)
+        context.adapter_fusion_attentions = defaultdict(dict)
 
     def get_fusion_regularization_loss(self):
         reg_loss = 0.0

--- a/src/transformers/adapters/models/bart/adapter_model.py
+++ b/src/transformers/adapters/models/bart/adapter_model.py
@@ -58,6 +58,7 @@ class BartAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdap
         past_key_values=None,
         head=None,
         output_adapter_gating_scores=False,
+        output_adapter_fusion_attentions=False,
         **kwargs
     ):
         r"""
@@ -87,6 +88,7 @@ class BartAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdap
             return_dict=return_dict,
             past_key_values=past_key_values,
             output_adapter_gating_scores=output_adapter_gating_scores,
+        output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
         # sequence classification based on last token in sequence
         x = outputs[0]  # last hidden state

--- a/src/transformers/adapters/models/bart/adapter_model.py
+++ b/src/transformers/adapters/models/bart/adapter_model.py
@@ -88,7 +88,7 @@ class BartAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdap
             return_dict=return_dict,
             past_key_values=past_key_values,
             output_adapter_gating_scores=output_adapter_gating_scores,
-        output_adapter_fusion_attentions=output_adapter_fusion_attentions,
+            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
         # sequence classification based on last token in sequence
         x = outputs[0]  # last hidden state

--- a/src/transformers/adapters/models/bert/adapter_model.py
+++ b/src/transformers/adapters/models/bert/adapter_model.py
@@ -45,6 +45,7 @@ class BertAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdap
         return_dict=None,
         head=None,
         output_adapter_gating_scores=False,
+        output_adapter_fusion_attentions=False,
         **kwargs
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -70,6 +71,7 @@ class BertAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdap
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             output_adapter_gating_scores=output_adapter_gating_scores,
+            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:

--- a/src/transformers/adapters/models/deberta/adapter_model.py
+++ b/src/transformers/adapters/models/deberta/adapter_model.py
@@ -39,6 +39,7 @@ class DebertaAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsA
         return_dict=None,
         head=None,
         output_adapter_gating_scores=False,
+        output_adapter_fusion_attentions=False,
         **kwargs
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -63,6 +64,7 @@ class DebertaAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsA
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             output_adapter_gating_scores=output_adapter_gating_scores,
+            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:

--- a/src/transformers/adapters/models/debertaV2/adapter_model.py
+++ b/src/transformers/adapters/models/debertaV2/adapter_model.py
@@ -42,6 +42,7 @@ class DebertaV2AdapterModel(
         return_dict=None,
         head=None,
         output_adapter_gating_scores=False,
+        output_adapter_fusion_attentions=False,
         **kwargs
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -66,6 +67,7 @@ class DebertaV2AdapterModel(
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             output_adapter_gating_scores=output_adapter_gating_scores,
+            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:

--- a/src/transformers/adapters/models/distilbert/adapter_model.py
+++ b/src/transformers/adapters/models/distilbert/adapter_model.py
@@ -71,6 +71,7 @@ class DistilBertAdapterModel(
         return_dict=None,
         head=None,
         output_adapter_gating_scores=False,
+        output_adapter_fusion_attentions=False,
         **kwargs
     ):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -92,6 +93,7 @@ class DistilBertAdapterModel(
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             output_adapter_gating_scores=output_adapter_gating_scores,
+            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
 
         outputs = self.forward_head(

--- a/src/transformers/adapters/models/gpt2/adapter_model.py
+++ b/src/transformers/adapters/models/gpt2/adapter_model.py
@@ -60,6 +60,7 @@ class GPT2AdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdap
         return_dict=None,
         head=None,
         output_adapter_gating_scores=False,
+        output_adapter_fusion_attentions=False,
         **kwargs
     ):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -79,6 +80,7 @@ class GPT2AdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdap
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             output_adapter_gating_scores=output_adapter_gating_scores,
+            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
 
         batch_size = outputs[0].shape[0]

--- a/src/transformers/adapters/models/mbart/adapter_model.py
+++ b/src/transformers/adapters/models/mbart/adapter_model.py
@@ -58,6 +58,7 @@ class MBartAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAda
         past_key_values=None,
         head=None,
         output_adapter_gating_scores=False,
+        output_adapter_fusion_attentions=False,
         **kwargs
     ):
         r"""
@@ -87,6 +88,7 @@ class MBartAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAda
             return_dict=return_dict,
             past_key_values=past_key_values,
             output_adapter_gating_scores=output_adapter_gating_scores,
+            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
         # sequence classification based on last token in sequence
         x = outputs[0]  # last hidden state

--- a/src/transformers/adapters/models/roberta/adapter_model.py
+++ b/src/transformers/adapters/models/roberta/adapter_model.py
@@ -50,6 +50,7 @@ class RobertaAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsA
         return_dict=None,
         head=None,
         output_adapter_gating_scores=False,
+        output_adapter_fusion_attentions=False,
         **kwargs
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -75,6 +76,7 @@ class RobertaAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsA
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             output_adapter_gating_scores=output_adapter_gating_scores,
+            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:

--- a/src/transformers/adapters/models/t5/adapter_model.py
+++ b/src/transformers/adapters/models/t5/adapter_model.py
@@ -54,6 +54,7 @@ class T5AdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdapte
         return_dict=None,
         head=None,
         output_adapter_gating_scores=False,
+        output_adapter_fusion_attentions=False,
         **kwargs
     ):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -78,6 +79,7 @@ class T5AdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAdapte
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             output_adapter_gating_scores=output_adapter_gating_scores,
+            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
         sequence_output = model_output[0]
         # ToDo move head to device for parallel forward pass

--- a/src/transformers/adapters/models/vit/adapter_model.py
+++ b/src/transformers/adapters/models/vit/adapter_model.py
@@ -34,6 +34,7 @@ class ViTAdapterModel(ModelWithFlexibleHeadsAdaptersMixin, ViTPreTrainedModel):
         return_dict: Optional[bool] = None,
         head=None,
         output_adapter_gating_scores=False,
+        output_adapter_fusion_attentions=False,
         **kwargs,
     ):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -46,6 +47,7 @@ class ViTAdapterModel(ModelWithFlexibleHeadsAdaptersMixin, ViTPreTrainedModel):
             interpolate_pos_encoding=interpolate_pos_encoding,
             return_dict=return_dict,
             output_adapter_gating_scores=output_adapter_gating_scores,
+            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
         )
 
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads

--- a/tests_adapters/test_encoder_decoder.py
+++ b/tests_adapters/test_encoder_decoder.py
@@ -77,3 +77,7 @@ class EncoderDecoderAdapterTest(
     def test_output_adapter_gating_scores_unipelt(self):
         # TODO currently not supported
         self.skipTest("Not implemented.")
+
+    def test_output_adapter_fusion_attentions(self):
+        # TODO currently not supported
+        self.skipTest("Not implemented.")


### PR DESCRIPTION
Example:
```python
model = AutoAdapterModel.from_pretrained("bert-base-uncased")
model.eval()

tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")

model.add_adapter("a")
model.add_adapter("b")
model.add_adapter_fusion(["a", "b"])

model.active_adapters = Fuse("a", "b")

input_data = tokenizer("this is great", return_tensors="pt")

output_1 = model(**input_data, output_adapter_fusion_attentions=True)

print(output_1.adapter_fusion_attentions)
```