### PR TITLE
Add GH action for stale issues bot

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues Bot'
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          exempt-issue-labels: 'do-not-close'
+          stale-issue-message: 'This issue has been automatically marked as stale because it has been without activity for 90 days. This issue will be closed in 14 days unless you comment or remove the stale label.'
+          close-issue-message: 'This issue was closed because it was stale for 14 days without any activity.'
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          days-before-pr-close: -1
+          days-before-pr-stale: -1

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,4 +1,4 @@
-name: 'Close stale issues Bot'
+name: 'Stale issues Bot'
 
 on:
   schedule:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          exempt-issue-labels: 'do-not-close'
+          exempt-issue-labels: 'do-not-stale'
           stale-issue-message: 'This issue has been automatically marked as stale because it has been without activity for 90 days. This issue will be closed in 14 days unless you comment or remove the stale label.'
           close-issue-message: 'This issue was closed because it was stale for 14 days without any activity.'
           days-before-issue-stale: 90

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    
+    permissions:
+      issues: write
+    
     steps:
       - uses: actions/stale@v6
         with:


### PR DESCRIPTION
Mark issues as stale after 90 days and close them after 14 days of further inactivity