### PR TITLE
Fix bug in BEiT adapters

### DIFF
--- a/src/transformers/adapters/mixins/beit.py
+++ b/src/transformers/adapters/mixins/beit.py
@@ -17,11 +17,6 @@ class BeitLayerAdaptersMixin:
         self.attention_adapters = AdapterLayer("mh_adapter", self.config)
         self.attention_adapters._init_adapter_modules()
 
-
-class BeitOutputAdaptersMixin:
-    """Adds adapters to the BeitOutput module."""
-
-    def _init_adapter_modules(self):
         self.output_adapters = AdapterLayer("output_adapter", self.config)
         self.output_adapters._init_adapter_modules()
 


### PR DESCRIPTION
This pull request fixes a bug in the BEiT adapter implementation, which I contributed in the first place. Although the tests were successful and the model converged on the test data set, during latest experimentation I became aware that the model in Adapter-Transformers, when it was *not* equipped with adapters, did output different embeddings than the original HF-Transformers model, which is obviously not intended. The bug fix contains two changes:

- Move the attention adapters call to the first residual connection, instead of calling it before lambda_1.
- Move the output adapters call into BeitLayer. In contrast to e.g. ViT it cannot be called in <Model>Output, due to the necessary lambda_2 and drop_path calls in BeitLayer before adapters need to be called.

This ensures that the model without adapters has the same output as the original HF-Transformers model it is built upon. In addition, I observed a significantly faster convergence on the same training data set as before (EuroSAT): previously it achieved 88 % accuracy after 10 epochs, now it achieves 97.4 % accuracy after 1 epoch and 98.2 % accuracy after 3 epochs. The newly observed convergence rate is similar to that of ViT with adapters. 