### PR TITLE
Fix DeBERTa prefix tuning w. enabled relative attention

### DIFF
--- a/tests_adapters/test_deberta.py
+++ b/tests_adapters/test_deberta.py
@@ -4,7 +4,14 @@ from tests.models.deberta.test_modeling_deberta import *
 from transformers import DebertaAdapterModel
 from transformers.testing_utils import require_torch
 
-from .methods import BottleneckAdapterTestMixin, UniPELTTestMixin, CompacterTestMixin, IA3TestMixin, LoRATestMixin, PrefixTuningTestMixin
+from .methods import (
+    BottleneckAdapterTestMixin,
+    CompacterTestMixin,
+    IA3TestMixin,
+    LoRATestMixin,
+    PrefixTuningTestMixin,
+    UniPELTTestMixin,
+)
 from .test_adapter import AdapterTestBase, make_config
 from .test_adapter_backward_compability import CompabilityTestMixin
 from .test_adapter_composition import ParallelAdapterInferenceTestMixin, ParallelTrainingMixin
@@ -32,6 +39,8 @@ class DebertaAdapterTestBase(AdapterTestBase):
         num_attention_heads=4,
         intermediate_size=37,
         hidden_act="gelu",
+        relative_attention=True,
+        pos_att_type="p2c|c2p",
     )
     tokenizer_name = "microsoft/deberta-base"
 

--- a/tests_adapters/test_debertaV2.py
+++ b/tests_adapters/test_debertaV2.py
@@ -4,7 +4,14 @@ from tests.models.deberta_v2.test_modeling_deberta_v2 import *
 from transformers import DebertaV2AdapterModel
 from transformers.testing_utils import require_torch
 
-from .methods import BottleneckAdapterTestMixin, UniPELTTestMixin, CompacterTestMixin, IA3TestMixin, LoRATestMixin, PrefixTuningTestMixin
+from .methods import (
+    BottleneckAdapterTestMixin,
+    CompacterTestMixin,
+    IA3TestMixin,
+    LoRATestMixin,
+    PrefixTuningTestMixin,
+    UniPELTTestMixin,
+)
 from .test_adapter import AdapterTestBase, make_config
 from .test_adapter_backward_compability import CompabilityTestMixin
 from .test_adapter_composition import ParallelAdapterInferenceTestMixin, ParallelTrainingMixin
@@ -32,6 +39,8 @@ class DebertaV2AdapterTestBase(AdapterTestBase):
         num_attention_heads=4,
         intermediate_size=37,
         hidden_act="gelu",
+        relative_attention=True,
+        pos_att_type="p2c|c2p",
     )
     tokenizer_name = "microsoft/deberta-v3-base"
 


### PR DESCRIPTION
Current implementation of prefix tuning is incompatible with relative attention of DeBERTa/ DeBERTa v2 (`relative_attention=True`), i.e. throws errors on position-to-content & content-to-position attentions. This PR removes prefix tokens from relative attention computation.