### PR TITLE
Add adapter configuration strings & restructure adapter method docs

### DIFF
--- a/adapter_docs/index.rst
+++ b/adapter_docs/index.rst
@@ -23,8 +23,15 @@ Currently, we support the PyTorch versions of all models as listed on the `Model
 
    installation
    quickstart
-   overview
    training
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Adapter Methods
+
+   overview
+   methods
+   method_combinations
 
 .. toctree::
    :maxdepth: 2

--- a/adapter_docs/method_combinations.md
+++ b/adapter_docs/method_combinations.md
@@ -1,0 +1,124 @@
+# Method Combinations
+
+_Configuration class_: [`ConfigUnion`](transformers.ConfigUnion)
+
+While different efficient fine-tuning methods and configurations have often been proposed as standalone, it might be beneficial to combine them for joint training.
+To make this process easier, adapter-transformers provides the possibility to group multiple configuration instances together using the `ConfigUnion` class.
+
+For example, this could be used to define different reduction factors for the adapter modules placed after the multi-head attention and the feed-forward blocks:
+
+```python
+from transformers.adapters import AdapterConfig, ConfigUnion
+
+config = ConfigUnion(
+    AdapterConfig(mh_adapter=True, output_adapter=False, reduction_factor=16, non_linearity="relu"),
+    AdapterConfig(mh_adapter=False, output_adapter=True, reduction_factor=2, non_linearity="relu"),
+)
+model.add_adapter("union_adapter", config=config)
+```
+
+## Mix-and-Match Adapters
+
+_Configuration class_: [`MAMConfig`](transformers.MAMConfig)
+
+[He et al. (2021)](https://arxiv.org/pdf/2110.04366.pdf) study various variants and combinations of efficient fine-tuning methods.
+Among others, they propose _Mix-and-Match Adapters_ as a combination of Prefix Tuning and parallel bottleneck adapters.
+This configuration is supported by adapter-transformers out-of-the-box:
+
+```python
+from transformers.adapters import MAMConfig
+
+config = MAMConfig()
+model.add_adapter("mam_adapter", config=config)
+```
+
+and is identical to using the following `ConfigUnion`:
+
+```python
+from transformers.adapters import ConfigUnion, ParallelConfig, PrefixTuningConfig
+
+config = ConfigUnion(
+    PrefixTuningConfig(bottleneck_size=800),
+    ParallelConfig(),
+)
+model.add_adapter("mam_adapter", config=config)
+```
+
+_Papers:_
+- [Towards a Unified View of Parameter-Efficient Transfer Learning](https://arxiv.org/pdf/2110.04366.pdf) (He et al., 2021)
+
+## UniPELT
+
+_Configuration class_: [`UniPELTConfig`](transformers.UniPELTConfig)
+
+```{eval-rst}
+.. figure:: img/unipelt.png
+    :height: 300
+    :align: center
+    :alt: Illustration of UniPELT.
+
+    Illustration of the UniPELT method within one Transformer layer. Trained components are colored in shades of magenta.
+```
+
+An approach similar to the work of [He et al. (2021)](https://arxiv.org/pdf/2110.04366.pdf) is taken by [Mao et al. (2022)](https://arxiv.org/pdf/2110.07577.pdf) in their _UniPELT_ framework.
+They, too, combine multiple efficient fine-tuning methods, namely LoRA, Prefix Tuning and bottleneck adapters, in a single unified setup.
+_UniPELT_ additionally introduces a gating mechanism that controls the activation of the different submodules.
+
+Concretely, for each adapted module $m$, UniPELT adds a trainable gating value $\mathcal{G}_m \in (0, 1)$ that is computed via a feed-forward network ($W_{\mathcal{G}_m}$) and sigmoid activation ($\sigma$) from the Transformer layer input states ($x$):
+
+$$\mathcal{G}_m \leftarrow \sigma(W_{\mathcal{G}_m} \cdot x)$$
+
+These gating values are then used to scale the output activations of the injected adapter modules, e.g. for a LoRA layer:
+
+$$
+h \leftarrow W_0 x + \mathcal{G}_{LoRA} B A x
+$$
+
+In the configuration classes of `adapter-transformers`, these gating mechanisms can be activated via `use_gating=True`.
+The full UniPELT setup can be instantiated using `UniPELTConfig`[^unipelt]:
+
+[^unipelt]: Note that the implementation of UniPELT in `adapter-transformers` follows the implementation in the original code, which is slighlty different from the description in the paper. See [here](https://github.com/morningmoni/UniPELT/issues/1) for more.
+
+```python
+from transformers.adapters import UniPELTConfig
+
+config = UniPELTConfig()
+model.add_adapter("unipelt", config=config)
+```
+
+which is identical to the following `ConfigUnion`:
+
+```python
+from transformers.adapters import ConfigUnion, LoRAConfig, PrefixTuningConfig, PfeifferConfig
+
+config = ConfigUnion(
+    LoRAConfig(r=8, use_gating=True),
+    PrefixTuningConfig(prefix_length=10, use_gating=True),
+    PfeifferConfig(reduction_factor=16, use_gating=True),
+)
+model.add_adapter("unipelt", config=config)
+```
+
+Finally, as the gating values for each adapter module might provide interesting insights for analysis, `adapter-transformers` comes with an integrated mechanism of returning all gating values computed during a model forward pass via the `output_adapter_gating_scores` parameter:
+
+```python
+outputs = model(**inputs, output_adapter_gating_scores=True)
+gating_scores = outputs.adapter_gating_scores
+```
+Note that this parameter is only available to base model classes and [AdapterModel classes](prediction_heads.md#adaptermodel-classes).
+In the example, `gating_scores` holds a dictionary of the following form:
+```
+{
+    '<adapter_name>': {
+        <layer_id>: {
+            '<module_location>': np.array([...]),
+            ...
+        },
+        ...
+    },
+    ...
+}
+```
+
+_Papers:_
+- [UNIPELT: A Unified Framework for Parameter-Efficient Language Model Tuning](https://arxiv.org/pdf/2110.07577.pdf) (Mao et al., 2022)

--- a/adapter_docs/methods.md
+++ b/adapter_docs/methods.md
@@ -1,0 +1,269 @@
+# Adapter Methods
+
+On this page, we present all adapter methods currently integrated into the `adapter-transformers` library.
+A tabulary overview of adapter methods is provided [here](overview.html#table-of-adapter-methods)
+Additionally, options to combine multiple adapter methods in a single setup are presented [on the next page](method_combinations.md).
+
+## Bottleneck Adapters
+
+_Configuration class_: [`AdapterConfig`](transformers.AdapterConfig)
+
+Bottleneck adapters introduce bottleneck feed-forward layers in each layer of a Transformer model.
+Generally, these adapter layers consist of a down-projection matrix $W_{down}$ that projects the layer hidden states into a lower dimension $d_{bottleneck}$, a non-linearity $f$, an up-projection $W_{up}$ that projects back into the original hidden layer dimension and a residual connection $r$:
+
+$$
+h \leftarrow W_{up} \cdot f(W_{down} \cdot h) + r
+$$
+
+Depending on the concrete adapter configuration, these layers can be introduced at different locations within a Transformer block. Further, residual connections, layer norms, activation functions and bottleneck sizes etc. can be configured.
+
+The most important configuration hyperparameter to be highlighted here is the bottleneck dimension $d_{bottleneck}$.
+In adapter-transformers, this bottleneck dimension is specified indirectly via the `reduction_factor` attribute of a configuration.
+This `reduction_factor` defines the ratio between a model's layer hidden dimension and the bottleneck dimension, i.e.:
+
+$$
+\text{reduction_factor} = \frac{d_{hidden}}{d_{bottleneck}}
+$$
+
+A visualization of further configuration options related to the adapter structure is given in the figure below. For more details, refer to the documentation of [`AdapterConfig`](transformers.AdapterConfig).
+
+
+```{eval-rst}
+.. figure:: img/architecture.png
+    :width: 350
+    :align: center
+    :alt: Adapter architectures
+
+    Visualization of possible adapter configurations with corresponding dictionary keys.
+```
+
+adapter-transformers comes with pre-defined configurations for some bottleneck adapter architectures proposed in literature:
+
+- [`HoulsbyConfig`](transformers.HoulsbyConfig) as proposed by [Houlsby et al. (2019)](https://arxiv.org/pdf/1902.00751.pdf) places adapter layers after both the multi-head attention and feed-forward block in each Transformer layer.
+- [`PfeifferConfig`](transformers.PfeifferConfig) as proposed by [Pfeiffer et al. (2020)](https://arxiv.org/pdf/2005.00052.pdf) places an adapter layer only after the feed-forward block in each Transformer layer.
+- [`ParallelConfig`](transformers.ParallelConfig) as proposed by [He et al. (2021)](https://arxiv.org/pdf/2110.04366.pdf) places adapter layers in parallel to the original Transformer layers.
+
+_Example_:
+```python
+from transformers.adapters import AdapterConfig
+
+config = AdapterConfig(mh_adapter=True, output_adapter=True, reduction_factor=16, non_linearity="relu")
+model.add_adapter("bottleneck_adapter", config=config)
+```
+
+_Papers:_
+
+* [Parameter-Efficient Transfer Learning for NLP](https://arxiv.org/pdf/1902.00751.pdf) (Houlsby et al., 2019)
+* [Simple, Scalable Adaptation for Neural Machine Translation](https://arxiv.org/pdf/1909.08478.pdf) (Bapna and Firat, 2019)
+* [AdapterFusion: Non-Destructive Task Composition for Transfer Learning](https://aclanthology.org/2021.eacl-main.39.pdf) (Pfeiffer et al., 2021)
+* [AdapterHub: A Framework for Adapting Transformers](https://arxiv.org/pdf/2007.07779.pdf) (Pfeiffer et al., 2020)
+
+## Language Adapters - Invertible Adapters
+
+_Configuration class_: [`PfeifferInvConfig`](transformers.PfeifferInvConfig), [`HoulsbyInvConfig`](transformers.HoulsbyInvConfig)
+
+The MAD-X setup ([Pfeiffer et al., 2020](https://arxiv.org/pdf/2005.00052.pdf)) proposes language adapters to learn language-specific transformations.
+After being trained on a language modeling task, a language adapter can be stacked before a task adapter for training on a downstream task.
+To perform zero-shot cross-lingual transfer, one language adapter can simply be replaced by another.
+
+In terms of architecture, language adapters are largely similar to regular bottleneck adapters, except for an additional _invertible adapter_ layer after the LM embedding layer.
+Embedding outputs are passed through this invertible adapter in the forward direction before entering the first Transformer layer and in the inverse direction after leaving the last Transformer layer.
+Invertible adapter architectures are further detailed in [Pfeiffer et al. (2020)](https://arxiv.org/pdf/2005.00052.pdf) and can be configured via the `inv_adapter` attribute of the `AdapterConfig` class.
+
+_Example_:
+```python
+from transformers.adapters import PfeifferInvConfig
+
+config = PfeifferInvConfig()
+model.add_adapter("lang_adapter", config=config)
+```
+
+_Papers:_
+- [MAD-X: An Adapter-based Framework for Multi-task Cross-lingual Transfer](https://arxiv.org/pdf/2005.00052.pdf) (Pfeiffer et al., 2020)
+
+```{eval-rst}
+.. note::
+    V1.x of adapter-transformers made a distinction between task adapters (without invertible adapters) and language adapters (with invertible adapters) with the help of the ``AdapterType`` enumeration.
+    This distinction was dropped with v2.x.
+```
+
+## Prefix Tuning
+
+_Configuration class_: [`PrefixTuningConfig`](transformers.PrefixTuningConfig)
+
+```{eval-rst}
+.. figure:: img/prefix.png
+    :height: 300
+    :align: center
+    :alt: Illustration of Prefix Tuning.
+
+    Illustration of the Prefix Tuning method within one Transformer layer. Trained components are colored in shades of magenta.
+```
+
+Prefix Tuning ([Li and Liang, 2021](https://aclanthology.org/2021.acl-long.353.pdf)) introduces new parameters in the multi-head attention blocks in each Transformer layer.
+More, specifically, it prepends trainable prefix vectors $P^K$ and $P^V$ to the keys and values of the attention head input, each of a configurable prefix length $l$ (`prefix_length` attribute):
+
+$$
+head_i = \text{Attention}(Q W_i^Q, [P_i^K, K W_i^K], [P_i^V, V W_i^V])
+$$
+
+Following the original authors, the prefix vectors in $P^K$ and $P^V$ are note optimized directly, but reparameterized via a bottleneck MLP.
+This behavior is controlled via the `flat` attribute of the configuration.
+Using `PrefixTuningConfig(flat=True)` will create prefix tuning vectors that are optimized without reparameterization.
+
+_Example_:
+```python
+from transformers.adapters import PrefixTuningConfig
+
+config = PrefixTuningConfig(flat=False, prefix_length=30)
+model.add_adapter("prefix_tuning", config=config)
+```
+
+As reparameterization using the bottleneck MLP is not necessary for performing inference on an already trained Prefix Tuning module, adapter-transformers includes a function to "eject" a reparameterized Prefix Tuning into a flat one:
+```python
+model.eject_prefix_tuning("prefix_tuning")
+```
+This will only retain the necessary parameters and reduces the size of the trained Prefix Tuning.
+
+_Papers:_
+- [Prefix-Tuning: Optimizing Continuous Prompts for Generation](https://arxiv.org/pdf/2101.00190.pdf) (Li and Liang, 2021)
+
+## Compacter
+
+_Configuration class_: [`CompacterConfig`](transformers.CompacterConfig), [`CompacterPlusPlusConfig`](transformers.CompacterPlusPlusConfig)
+
+```{eval-rst}
+.. figure:: img/compacter.png
+    :height: 300
+    :align: center
+    :alt: Illustration of Compacter.
+
+    Illustration of the Compacter method within one Transformer layer. Trained components are colored in shades of magenta.
+```
+
+The Compacter architecture proposed by [Mahabadi et al., 2021](https://arxiv.org/pdf/2106.04647.pdf)
+is similar to the bottleneck adapter architecture. It only exchanges the linear down- and 
+up-projection with a PHM layer. Unlike the linear layer, the PHM layer constructs its weight matrix from two smaller matrices, which reduces the number of parameters.
+ These matrices can be factorized and shared between all adapter layers. You can exchange the down- and up-projection layers from any of the bottleneck adapters described in the previous section
+for a PHM layer by specifying `use_phm=True` in the config.
+
+The PHM layer has the following additional properties: `phm_dim`, `shared_phm_rule`, `factorized_phm_rule`, `learn_phm`, 
+`factorized_phm_W`, `shared_W_phm`, `phm_c_init`, `phm_init_range`, `hypercomplex_nonlinearity`
+
+For more information check out the [`AdapterConfig`](transformers.AdapterConfig) class.
+
+To add a Compacter to your model you can use the predefined configs:
+```python
+from transformers.adapters import CompacterConfig
+
+config = CompacterConfig()
+model.add_adapter("dummy", config=config)
+```
+_Papers:_
+- [COMPACTER: Efficient Low-Rank Hypercomplex Adapter Layers](https://arxiv.org/pdf/2106.04647.pdf) (Mahabadi, Henderson and Ruder, 2021)
+
+## LoRA
+
+_Configuration class_: [`LoRAConfig`](transformers.LoRAConfig)
+
+```{eval-rst}
+.. figure:: img/lora.png
+    :height: 300
+    :align: center
+    :alt: Illustration of LoRA.
+
+    Illustration of the LoRA method within one Transformer layer. Trained components are colored in shades of magenta.
+```
+
+Low-Rank Adaptation (LoRA) is an efficient fine-tuning technique proposed by [Hu et al. (2021)](https://arxiv.org/pdf/2106.09685.pdf).
+LoRA injects trainable low-rank decomposition matrices into the layers of a pre-trained model.
+For any model layer expressed as a matrix multiplication of the form $h = W_0 x$, it therefore performs a reparameterization, such that:
+
+$$
+h = W_0 x + \frac{\alpha}{r} B A x
+$$
+
+Here, $A \in \mathbb{R}^{r\times k}$ and $B \in \mathbb{R}^{d\times r}$ are the decomposition matrices and $r$, the low-dimensional rank of the decomposition, is the most important hyperparameter.
+
+While, in principle, this reparameterization can be applied to any weights matrix in a model, the original paper only adapts the attention weights of the Transformer self-attention sub-layer with LoRA.
+`adapter-transformers` additionally allows injecting LoRA into the dense feed-forward layers in the intermediate and output components of a Transformer block.
+You can configure the locations where LoRA weights should be injected using the attributes in the [`LoRAConfig`](transformers.LoRAConfig) class.
+
+_Example_:
+```python
+from transformers.adapters import LoRAConfig
+
+config = LoRAConfig(r=8, alpha=16)
+model.add_adapter("lora_adapter", config=config)
+```
+
+In the design of LoRA, Hu et al. (2021) also pay special attention to keeping the inference latency overhead compared to full fine-tuning at a minimum.
+To accomplish this, the LoRA reparameterization can be merged with the original pre-trained weights of a model for inference.
+Thus, the adapted weights are directly used in every forward pass without passing activations through an additional module.
+In `adapter-transformers`, this can be realized using the built-in `merge_adapter()` method:
+```python
+model.merge_adapter("lora_adapter")
+```
+
+To continue training on this LoRA adapter or to deactivate it entirely, the merged weights first have to be reset again:
+```python
+model.reset_adapter("lora_adapter")
+```
+
+_Papers:_
+- [LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/pdf/2106.09685.pdf) (Hu et al., 2021)
+
+## (IA)^3
+
+_Configuration class_: [`IA3Config`](transformers.IA3Config)
+
+```{eval-rst}
+.. figure:: img/ia3.png
+    :height: 300
+    :align: center
+    :alt: Illustration of (IA)^3.
+
+    Illustration of the (IA)^3 method within one Transformer layer. Trained components are colored in shades of magenta.
+```
+
+_Infused Adapter by Inhibiting and Amplifying Inner Activations ((IA)^3)_ is an efficient fine-tuning method proposed within the _T-Few_ fine-tuning approach by [Liu et al. (2022)](https://arxiv.org/pdf/2205.05638.pdf).
+(IA)^3 introduces trainable vectors $l_W$ into different components of a Transformer model which perform element-wise rescaling of inner model activations.
+For any model layer expressed as a matrix multiplication of the form $h = W x$, it therefore performs an element-wise multiplication with $l_W$, such that:
+
+$$
+h = l_W \odot W x
+$$
+
+Here, $\odot$ denotes element-wise multiplication where the entries of $l_W$ are broadcasted to the shape of $W$.
+
+_Example_:
+```python
+from transformers.adapters import IA3Config
+
+config = IA3Config()
+model.add_adapter("ia3_adapter", config=config)
+```
+
+The implementation of (IA)^3, as well as the `IA3Config` class, are derived from the implementation of [LoRA](#lora), with a few main modifications.
+First, (IA)^3 uses multiplicative composition of weights instead of additive composition as in LoRA.
+Second, the added weights are not further decomposed into low-rank matrices.
+Both of these modifications are controlled via the `composition_mode` configuration attribute by setting `composition_mode="scale"`.
+Additionally, as the added weights are already of rank 1, `r=1` is set.
+
+Beyond that, both methods share the same configuration attributes that allow you to specify in which Transformer components rescaling vectors will be injected.
+Following the original implementation, `IA3Config` adds rescaling vectors to the self-attention weights (`selfattn_lora=True`) and the final feed-forward layer (`output_lora=True`).
+Further, you can modify which matrices of the attention mechanism to rescale by leveraging the `attn_matrices` attribute.
+By default, (IA)^3 injects weights into the key ('k') and value ('v') matrices, but not in the query ('q') matrix.
+
+Finally, similar to LoRA, (IA)^3 also allows merging the injected parameters with the original weight matrices of the Transformer model.
+E.g.:
+```python
+# Merge (IA)^3 adapter
+model.merge_adapter("ia3_adapter")
+
+# Reset merged weights
+model.reset_adapter("ia3_adapter")
+```
+
+_Papers:_
+- [Few-Shot Parameter-Efficient Fine-Tuning is Better and Cheaper than In-Context Learning](https://arxiv.org/pdf/2205.05638.pdf) (Liu et al., 2022)

--- a/adapter_docs/overview.md
+++ b/adapter_docs/overview.md
@@ -1,4 +1,4 @@
-# Overview: Efficient Fine-Tuning Methods
+# Overview and Configuration
 
 Large pre-trained Transformer-based language models (LMs) have become the foundation of NLP in recent years.
 While the most prevalent method of using these LMs for transfer learning involves costly *full fine-tuning* of all model parameters, a series of *efficient* and *lightweight* alternatives have been established in recent time.
@@ -25,15 +25,6 @@ $$
 Efficient fine-tuning might insert parameters $\Phi$ at different locations of a Transformer-based LM.
 One early and successful method, (bottleneck) adapters, introduces bottleneck feed-forward layers in each layer of a Transformer model.
 While these adapters have laid the foundation of the adapter-transformers library, multiple alternative methods have been introduced and integrated since.
-In the following, we present all methods currently integrated into this library (see [here](https://github.com/adapter-hub/adapter-transformers#implemented-methods) for a tabular overview).
-
-**Configuration:** All presented methods can be added, trained, saved and shared using the same set of model class functions (see [class documentation](transformers.ModelAdaptersMixin)).
-Each method is specified and configured using a specific configuration class, all of which derive from the common [`AdapterConfigBase`](transformers.AdapterConfigBase) class.
-E.g., adding one of the methods presented below to an existing model instance follows this scheme:
-```python
-config = ... # config class deriving from AdapterConfigBase
-model.add_adapter("name", config=config)
-```
 
 ```{eval-rst}
 .. important::
@@ -43,391 +34,61 @@ model.add_adapter("name", config=config)
     In adapter-transformers, the term "adapter" thus may refer to any efficient fine-tuning method if not specified otherwise.
 ```
 
-## Bottleneck Adapters
+In the remaining sections, we will present how adapter methods can be configured in `adapter-transformers`.
+The next two pages will then present the methodological details of all currently supported adapter methods.
 
-_Configuration class_: [`AdapterConfig`](transformers.AdapterConfig)
+## Table of Adapter Methods
 
-Bottleneck adapters introduce bottleneck feed-forward layers in each layer of a Transformer model.
-Generally, these adapter layers consist of a down-projection matrix $W_{down}$ that projects the layer hidden states into a lower dimension $d_{bottleneck}$, a non-linearity $f$, an up-projection $W_{up}$ that projects back into the original hidden layer dimension and a residual connection $r$:
+The following table gives an overview of all adapter methods supported by `adapter-transformers`.
+Identifiers and configuration classes are explained in more detail in the [next section](#configuration).
 
-$$
-h \leftarrow W_{up} \cdot f(W_{down} \cdot h) + r
-$$
+| Identifier | Configuration class | More information
+| --- | --- | --- |
+| `pfeiffer` | `PfeifferConfig()` | [Bottleneck Adapters](methods.html#bottleneck-adapters) |
+| `houlsby` | `HoulsbyConfig()` | [Bottleneck Adapters](methods.html#bottleneck-adapters) |
+| `parallel` | `ParallelConfig()` | [Bottleneck Adapters](methods.html#bottleneck-adapters) |
+| `scaled_parallel` | `ParallelConfig(scaling="learned")` | [Bottleneck Adapters](methods.html#bottleneck-adapters) |
+| `pfeiffer+inv` | `PfeifferInvConfig()` | [Invertible Adapters](methods.html#language-adapters---invertible-adapters) |
+| `houlsby+inv` | `HoulsbyInvConfig()` | [Invertible Adapters](methods.html#language-adapters---invertible-adapters) |
+| `compacter` | `CompacterConfig()` | [Compacter](methods.html#compacter) |
+| `compacter++` | `CompacterPlusPlusConfig()` | [Compacter](methods.html#compacter) |
+| `prefix_tuning` | `PrefixTuningConfig()` | [Prefix Tuning](methods.html#prefix-tuning) |
+| `prefix_tuning_flat` | `PrefixTuningConfig(flat=True)` | [Prefix Tuning](methods.html#prefix-tuning) |
+| `lora` | `LoRAConfig()` | [LoRA](methods.html#lora) |
+| `ia3` | `IA3Config()` | [IA³](methods.html#ia3) |
+| `mam` | `MAMConfig()` | [Mix-and-Match Adapters](method_combinations.html#mix-and-match-adapters) |
+| `unipelt` | `UniPELTConfig()` | [UniPELT](method_combinations.html#unipelt) |
 
-Depending on the concrete adapter configuration, these layers can be introduced at different locations within a Transformer block. Further, residual connections, layer norms, activation functions and bottleneck sizes etc. can be configured.
+## Configuration
 
-The most important configuration hyperparameter to be highlighted here is the bottleneck dimension $d_{bottleneck}$.
-In adapter-transformers, this bottleneck dimension is specified indirectly via the `reduction_factor` attribute of a configuration.
-This `reduction_factor` defines the ratio between a model's layer hidden dimension and the bottleneck dimension, i.e.:
-
-$$
-\text{reduction_factor} = \frac{d_{hidden}}{d_{bottleneck}}
-$$
-
-A visualization of further configuration options related to the adapter structure is given in the figure below. For more details, refer to the documentation of [`AdapterConfig`](transformers.AdapterConfig).
-
-
-```{eval-rst}
-.. figure:: img/architecture.png
-    :width: 350
-    :align: center
-    :alt: Adapter architectures
-
-    Visualization of possible adapter configurations with corresponding dictionary keys.
-```
-
-adapter-transformers comes with pre-defined configurations for some bottleneck adapter architectures proposed in literature:
-
-- [`HoulsbyConfig`](transformers.HoulsbyConfig) as proposed by [Houlsby et al. (2019)](https://arxiv.org/pdf/1902.00751.pdf) places adapter layers after both the multi-head attention and feed-forward block in each Transformer layer.
-- [`PfeifferConfig`](transformers.PfeifferConfig) as proposed by [Pfeiffer et al. (2020)](https://arxiv.org/pdf/2005.00052.pdf) places an adapter layer only after the feed-forward block in each Transformer layer.
-- [`ParallelConfig`](transformers.ParallelConfig) as proposed by [He et al. (2021)](https://arxiv.org/pdf/2110.04366.pdf) places adapter layers in parallel to the original Transformer layers.
-
-_Example_:
+All supported adapter methods can be added, trained, saved and shared using the same set of model class functions (see [class documentation](transformers.ModelAdaptersMixin)).
+Each method is specified and configured using a specific configuration class, all of which derive from the common [`AdapterConfigBase`](transformers.AdapterConfigBase) class.
+E.g., adding one of the supported adapter methods to an existing model instance follows this scheme:
 ```python
-from transformers.adapters import AdapterConfig
-
-config = AdapterConfig(mh_adapter=True, output_adapter=True, reduction_factor=16, non_linearity="relu")
-model.add_adapter("bottleneck_adapter", config=config)
+model.add_adapter("name", config=<ADAPTER_CONFIG>)
 ```
 
-_Papers:_
+Here, `<ADAPTER_CONFIG>` can either be:
+- a configuration string, as described below
+- an instance of a configuration class, as listed in the table above
+- a path to a JSON file containing a configuration dictionary
 
-* [Parameter-Efficient Transfer Learning for NLP](https://arxiv.org/pdf/1902.00751.pdf) (Houlsby et al., 2019)
-* [Simple, Scalable Adaptation for Neural Machine Translation](https://arxiv.org/pdf/1909.08478.pdf) (Bapna and Firat, 2019)
-* [AdapterFusion: Non-Destructive Task Composition for Transfer Learning](https://aclanthology.org/2021.eacl-main.39.pdf) (Pfeiffer et al., 2021)
-* [AdapterHub: A Framework for Adapting Transformers](https://arxiv.org/pdf/2007.07779.pdf) (Pfeiffer et al., 2020)
+### Configuration strings
 
-## Language Adapters - Invertible Adapters
+Configuration strings are a concise way of defining a specific adapter method configuration.
+They are especially useful when adapter configurations are passed from external sources such as the command-line, when using configuration classes is not an option.
 
-_Configuration class_: [`PfeifferInvConfig`](transformers.PfeifferInvConfig), [`HoulsbyInvConfig`](transformers.HoulsbyInvConfig)
+In general, a configuration string for a single method takes the form `<identifier>[<key>=<value>, ...]`.
+Here, `<identifier>` refers to one of the identifiers listed in [the table above](#table-of-adapter-methods), e.g. `parallel`.
+In square brackets after the identifier, you can set specific configuration attributes from the respective configuration class, e.g. `parallel[reduction_factor=2]`.
+If all attributes remain at their default values, this can be omitted.
 
-The MAD-X setup ([Pfeiffer et al., 2020](https://arxiv.org/pdf/2005.00052.pdf)) proposes language adapters to learn language-specific transformations.
-After being trained on a language modeling task, a language adapter can be stacked before a task adapter for training on a downstream task.
-To perform zero-shot cross-lingual transfer, one language adapter can simply be replaced by another.
-
-In terms of architecture, language adapters are largely similar to regular bottleneck adapters, except for an additional _invertible adapter_ layer after the LM embedding layer.
-Embedding outputs are passed through this invertible adapter in the forward direction before entering the first Transformer layer and in the inverse direction after leaving the last Transformer layer.
-Invertible adapter architectures are further detailed in [Pfeiffer et al. (2020)](https://arxiv.org/pdf/2005.00052.pdf) and can be configured via the `inv_adapter` attribute of the `AdapterConfig` class.
-
-_Example_:
-```python
-from transformers.adapters import PfeifferInvConfig
-
-config = PfeifferInvConfig()
-model.add_adapter("lang_adapter", config=config)
-```
-
-_Papers:_
-- [MAD-X: An Adapter-based Framework for Multi-task Cross-lingual Transfer](https://arxiv.org/pdf/2005.00052.pdf) (Pfeiffer et al., 2020)
-
-```{eval-rst}
-.. note::
-    V1.x of adapter-transformers made a distinction between task adapters (without invertible adapters) and language adapters (with invertible adapters) with the help of the ``AdapterType`` enumeration.
-    This distinction was dropped with v2.x.
-```
-
-## Prefix Tuning
-
-_Configuration class_: [`PrefixTuningConfig`](transformers.PrefixTuningConfig)
-
-```{eval-rst}
-.. figure:: img/prefix.png
-    :height: 300
-    :align: center
-    :alt: Illustration of Prefix Tuning.
-
-    Illustration of the Prefix Tuning method within one Transformer layer. Trained components are colored in shades of magenta.
-```
-
-Prefix Tuning ([Li and Liang, 2021](https://aclanthology.org/2021.acl-long.353.pdf)) introduces new parameters in the multi-head attention blocks in each Transformer layer.
-More, specifically, it prepends trainable prefix vectors $P^K$ and $P^V$ to the keys and values of the attention head input, each of a configurable prefix length $l$ (`prefix_length` attribute):
-
-$$
-head_i = \text{Attention}(Q W_i^Q, [P_i^K, K W_i^K], [P_i^V, V W_i^V])
-$$
-
-Following the original authors, the prefix vectors in $P^K$ and $P^V$ are note optimized directly, but reparameterized via a bottleneck MLP.
-This behavior is controlled via the `flat` attribute of the configuration.
-Using `PrefixTuningConfig(flat=True)` will create prefix tuning vectors that are optimized without reparameterization.
-
-_Example_:
-```python
-from transformers.adapters import PrefixTuningConfig
-
-config = PrefixTuningConfig(flat=False, prefix_length=30)
-model.add_adapter("prefix_tuning", config=config)
-```
-
-As reparameterization using the bottleneck MLP is not necessary for performing inference on an already trained Prefix Tuning module, adapter-transformers includes a function to "eject" a reparameterized Prefix Tuning into a flat one:
-```python
-model.eject_prefix_tuning("prefix_tuning")
-```
-This will only retain the necessary parameters and reduces the size of the trained Prefix Tuning.
-
-_Papers:_
-- [Prefix-Tuning: Optimizing Continuous Prompts for Generation](https://arxiv.org/pdf/2101.00190.pdf) (Li and Liang, 2021)
-
-## Compacter
-
-_Configuration class_: [`CompacterConfig`](transformers.CompacterConfig), [`CompacterPlusPlusConfig`](transformers.CompacterPlusPlusConfig)
-
-```{eval-rst}
-.. figure:: img/compacter.png
-    :height: 300
-    :align: center
-    :alt: Illustration of Compacter.
-
-    Illustration of the Compacter method within one Transformer layer. Trained components are colored in shades of magenta.
-```
-
-The Compacter architecture proposed by [Mahabadi et al., 2021](https://arxiv.org/pdf/2106.04647.pdf)
-is similar to the bottleneck adapter architecture. It only exchanges the linear down- and 
-up-projection with a PHM layer. Unlike the linear layer, the PHM layer constructs its weight matrix from two smaller matrices, which reduces the number of parameters.
- These matrices can be factorized and shared between all adapter layers. You can exchange the down- and up-projection layers from any of the bottleneck adapters described in the previous section
-for a PHM layer by specifying `use_phm=True` in the config.
-
-The PHM layer has the following additional properties: `phm_dim`, `shared_phm_rule`, `factorized_phm_rule`, `learn_phm`, 
-`factorized_phm_W`, `shared_W_phm`, `phm_c_init`, `phm_init_range`, `hypercomplex_nonlinearity`
-
-For more information check out the [`AdapterConfig`](transformers.AdapterConfig) class.
-
-To add a Compacter to your model you can use the predefined configs:
-```python
-from transformers.adapters import CompacterConfig
-
-config = CompacterConfig()
-model.add_adapter("dummy", config=config)
-```
-_Papers:_
-- [COMPACTER: Efficient Low-Rank Hypercomplex Adapter Layers](https://arxiv.org/pdf/2106.04647.pdf) (Mahabadi, Henderson and Ruder, 2021)
-
-## LoRA
-
-_Configuration class_: [`LoRAConfig`](transformers.LoRAConfig)
-
-```{eval-rst}
-.. figure:: img/lora.png
-    :height: 300
-    :align: center
-    :alt: Illustration of LoRA.
-
-    Illustration of the LoRA method within one Transformer layer. Trained components are colored in shades of magenta.
-```
-
-Low-Rank Adaptation (LoRA) is an efficient fine-tuning technique proposed by [Hu et al. (2021)](https://arxiv.org/pdf/2106.09685.pdf).
-LoRA injects trainable low-rank decomposition matrices into the layers of a pre-trained model.
-For any model layer expressed as a matrix multiplication of the form $h = W_0 x$, it therefore performs a reparameterization, such that:
-
-$$
-h = W_0 x + \frac{\alpha}{r} B A x
-$$
-
-Here, $A \in \mathbb{R}^{r\times k}$ and $B \in \mathbb{R}^{d\times r}$ are the decomposition matrices and $r$, the low-dimensional rank of the decomposition, is the most important hyperparameter.
-
-While, in principle, this reparameterization can be applied to any weights matrix in a model, the original paper only adapts the attention weights of the Transformer self-attention sub-layer with LoRA.
-`adapter-transformers` additionally allows injecting LoRA into the dense feed-forward layers in the intermediate and output components of a Transformer block.
-You can configure the locations where LoRA weights should be injected using the attributes in the [`LoRAConfig`](transformers.LoRAConfig) class.
-
-_Example_:
-```python
-from transformers.adapters import LoRAConfig
-
-config = LoRAConfig(r=8, alpha=16)
-model.add_adapter("lora_adapter", config=config)
-```
-
-In the design of LoRA, Hu et al. (2021) also pay special attention to keeping the inference latency overhead compared to full fine-tuning at a minimum.
-To accomplish this, the LoRA reparameterization can be merged with the original pre-trained weights of a model for inference.
-Thus, the adapted weights are directly used in every forward pass without passing activations through an additional module.
-In `adapter-transformers`, this can be realized using the built-in `merge_adapter()` method:
-```python
-model.merge_adapter("lora_adapter")
-```
-
-To continue training on this LoRA adapter or to deactivate it entirely, the merged weights first have to be reset again:
-```python
-model.reset_adapter("lora_adapter")
-```
-
-_Papers:_
-- [LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/pdf/2106.09685.pdf) (Hu et al., 2021)
-
-## (IA)^3
-
-_Configuration class_: [`IA3Config`](transformers.IA3Config)
-
-```{eval-rst}
-.. figure:: img/ia3.png
-    :height: 300
-    :align: center
-    :alt: Illustration of (IA)^3.
-
-    Illustration of the (IA)^3 method within one Transformer layer. Trained components are colored in shades of magenta.
-```
-
-_Infused Adapter by Inhibiting and Amplifying Inner Activations ((IA)^3)_ is an efficient fine-tuning method proposed within the _T-Few_ fine-tuning approach by [Liu et al. (2022)](https://arxiv.org/pdf/2205.05638.pdf).
-(IA)^3 introduces trainable vectors $l_W$ into different components of a Transformer model which perform element-wise rescaling of inner model activations.
-For any model layer expressed as a matrix multiplication of the form $h = W x$, it therefore performs an element-wise multiplication with $l_W$, such that:
-
-$$
-h = l_W \odot W x
-$$
-
-Here, $\odot$ denotes element-wise multiplication where the entries of $l_W$ are broadcasted to the shape of $W$.
-
-_Example_:
-```python
-from transformers.adapters import IA3Config
-
-config = IA3Config()
-model.add_adapter("ia3_adapter", config=config)
-```
-
-The implementation of (IA)^3, as well as the `IA3Config` class, are derived from the implementation of [LoRA](#lora), with a few main modifications.
-First, (IA)^3 uses multiplicative composition of weights instead of additive composition as in LoRA.
-Second, the added weights are not further decomposed into low-rank matrices.
-Both of these modifications are controlled via the `composition_mode` configuration attribute by setting `composition_mode="scale"`.
-Additionally, as the added weights are already of rank 1, `r=1` is set.
-
-Beyond that, both methods share the same configuration attributes that allow you to specify in which Transformer components rescaling vectors will be injected.
-Following the original implementation, `IA3Config` adds rescaling vectors to the self-attention weights (`selfattn_lora=True`) and the final feed-forward layer (`output_lora=True`).
-Further, you can modify which matrices of the attention mechanism to rescale by leveraging the `attn_matrices` attribute.
-By default, (IA)^3 injects weights into the key ('k') and value ('v') matrices, but not in the query ('q') matrix.
-
-Finally, similar to LoRA, (IA)^3 also allows merging the injected parameters with the original weight matrices of the Transformer model.
-E.g.:
-```python
-# Merge (IA)^3 adapter
-model.merge_adapter("ia3_adapter")
-
-# Reset merged weights
-model.reset_adapter("ia3_adapter")
-```
-
-_Papers:_
-- [Few-Shot Parameter-Efficient Fine-Tuning is Better and Cheaper than In-Context Learning](https://arxiv.org/pdf/2205.05638.pdf) (Liu et al., 2022)
-
-## Method Combinations
-
-_Configuration class_: [`ConfigUnion`](transformers.ConfigUnion)
-
-While different efficient fine-tuning methods and configurations have often been proposed as standalone, it might be beneficial to combine them for joint training.
-To make this process easier, adapter-transformers provides the possibility to group multiple configuration instances together using the `ConfigUnion` class.
-
-For example, this could be used to define different reduction factors for the adapter modules placed after the multi-head attention and the feed-forward blocks:
+Finally, it is also possible to specify a [method combination](method_combinations.md) as a configuration string by joining multiple configuration strings with `|`.
+E.g., `prefix_tuning[bottleneck_size=800]|parallel` is identical to the following configuration class instance:
 
 ```python
-from transformers.adapters import AdapterConfig, ConfigUnion
-
-config = ConfigUnion(
-    AdapterConfig(mh_adapter=True, output_adapter=False, reduction_factor=16, non_linearity="relu"),
-    AdapterConfig(mh_adapter=False, output_adapter=True, reduction_factor=2, non_linearity="relu"),
-)
-model.add_adapter("union_adapter", config=config)
-```
-
-### Mix-and-Match Adapters
-
-_Configuration class_: [`MAMConfig`](transformers.MAMConfig)
-
-[He et al. (2021)](https://arxiv.org/pdf/2110.04366.pdf) study various variants and combinations of efficient fine-tuning methods.
-Among others, they propose _Mix-and-Match Adapters_ as a combination of Prefix Tuning and parallel bottleneck adapters.
-This configuration is supported by adapter-transformers out-of-the-box:
-
-```python
-from transformers.adapters import MAMConfig
-
-config = MAMConfig()
-model.add_adapter("mam_adapter", config=config)
-```
-
-and is identical to using the following `ConfigUnion`:
-
-```python
-from transformers.adapters import ConfigUnion, ParallelConfig, PrefixTuningConfig
-
-config = ConfigUnion(
+ConfigUnion(
     PrefixTuningConfig(bottleneck_size=800),
     ParallelConfig(),
 )
-model.add_adapter("mam_adapter", config=config)
 ```
-
-_Papers:_
-- [Towards a Unified View of Parameter-Efficient Transfer Learning](https://arxiv.org/pdf/2110.04366.pdf) (He et al., 2021)
-
-### UniPELT
-
-_Configuration class_: [`UniPELTConfig`](transformers.UniPELTConfig)
-
-```{eval-rst}
-.. figure:: img/unipelt.png
-    :height: 300
-    :align: center
-    :alt: Illustration of UniPELT.
-
-    Illustration of the UniPELT method within one Transformer layer. Trained components are colored in shades of magenta.
-```
-
-An approach similar to the work of [He et al. (2021)](https://arxiv.org/pdf/2110.04366.pdf) is taken by [Mao et al. (2022)](https://arxiv.org/pdf/2110.07577.pdf) in their _UniPELT_ framework.
-They, too, combine multiple efficient fine-tuning methods, namely LoRA, Prefix Tuning and bottleneck adapters, in a single unified setup.
-_UniPELT_ additionally introduces a gating mechanism that controls the activation of the different submodules.
-
-Concretely, for each adapted module $m$, UniPELT adds a trainable gating value $\mathcal{G}_m \in (0, 1)$ that is computed via a feed-forward network ($W_{\mathcal{G}_m}$) and sigmoid activation ($\sigma$) from the Transformer layer input states ($x$):
-
-$$\mathcal{G}_m \leftarrow \sigma(W_{\mathcal{G}_m} \cdot x)$$
-
-These gating values are then used to scale the output activations of the injected adapter modules, e.g. for a LoRA layer:
-
-$$
-h \leftarrow W_0 x + \mathcal{G}_{LoRA} B A x
-$$
-
-In the configuration classes of `adapter-transformers`, these gating mechanisms can be activated via `use_gating=True`.
-The full UniPELT setup can be instantiated using `UniPELTConfig`[^unipelt]:
-
-[^unipelt]: Note that the implementation of UniPELT in `adapter-transformers` follows the implementation in the original code, which is slighlty different from the description in the paper. See [here](https://github.com/morningmoni/UniPELT/issues/1) for more.
-
-```python
-from transformers.adapters import UniPELTConfig
-
-config = UniPELTConfig()
-model.add_adapter("unipelt", config=config)
-```
-
-which is identical to the following `ConfigUnion`:
-
-```python
-from transformers.adapters import ConfigUnion, LoRAConfig, PrefixTuningConfig, PfeifferConfig
-
-config = ConfigUnion(
-    LoRAConfig(r=8, use_gating=True),
-    PrefixTuningConfig(prefix_length=10, use_gating=True),
-    PfeifferConfig(reduction_factor=16, use_gating=True),
-)
-model.add_adapter("unipelt", config=config)
-```
-
-Finally, as the gating values for each adapter module might provide interesting insights for analysis, `adapter-transformers` comes with an integrated mechanism of returning all gating values computed during a model forward pass via the `output_adapter_gating_scores` parameter:
-
-```python
-outputs = model(**inputs, output_adapter_gating_scores=True)
-gating_scores = outputs.adapter_gating_scores
-```
-Note that this parameter is only available to base model classes and [AdapterModel classes](prediction_heads.md#adaptermodel-classes).
-In the example, `gating_scores` holds a dictionary of the following form:
-```
-{
-    '<adapter_name>': {
-        <layer_id>: {
-            '<module_location>': np.array([...]),
-            ...
-        },
-        ...
-    },
-    ...
-}
-```
-
-_Papers:_
-- [UNIPELT: A Unified Framework for Parameter-Efficient Language Model Tuning](https://arxiv.org/pdf/2110.07577.pdf) (Mao et al., 2022)

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -408,8 +408,8 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
         Adds a new adapter module of the specified type to the model.
 
         Args:
-            adapter_name (str): The name of the adapter module to be added. config (str or dict or AdapterConfigBase,
-            optional): The adapter configuration, can be either:
+            adapter_name (str): The name of the adapter module to be added.
+            config (str or dict or AdapterConfigBase, optional): The adapter configuration, can be either:
 
                 - the string identifier of a pre-defined configuration dictionary
                 - a configuration dictionary specifying the full config
@@ -420,8 +420,7 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
                 Set the adapter to be the active one. By default (False),
             the adapter is added but not activated.
         """
-        if isinstance(config, dict):
-            config = AdapterConfigBase.load(config)  # ensure config is ok and up-to-date
+        config = AdapterConfigBase.load(config)  # ensure config is ok and up-to-date
         # In case adapter already exists and we allow overwriting, explicitly delete the existing one first
         if overwrite_ok and adapter_name in self.config.adapters:
             self.delete_adapter(adapter_name)

--- a/src/transformers/adapters/utils.py
+++ b/src/transformers/adapters/utils.py
@@ -1,3 +1,4 @@
+import ast
 import fnmatch
 import hashlib
 import inspect
@@ -16,7 +17,7 @@ from enum import Enum
 from functools import partial
 from os.path import basename, isdir, isfile, join
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 from zipfile import ZipFile, is_zipfile
 
@@ -82,6 +83,7 @@ ADAPTER_CONFIG_HASH_IGNORE_DEFAULT = {
     "init_weights": "bert",
     "scaling": 1.0,
 }
+ADAPTER_CONFIG_STRING_PATTERN = re.compile(r"^(?P<name>[^\[\]\|\n]+)(?:\[(?P<kvs>.*)\])?$")
 
 
 class AdapterType(str, Enum):
@@ -392,6 +394,35 @@ def download_cached(url, checksum=None, checksum_algo="sha1", cache_dir=None, fo
     return output_path_extracted
 
 
+def parse_adapter_config_string(config_string: str) -> List[Tuple[str, dict]]:
+    """
+    Parses an adapter configuration string into a list of tuples. Each tuple constists of an adapter config identifier
+    and dictionary.
+    """
+    # First split by "|" into individual adapter configs
+    config_string_chunks = config_string.split("|")
+    # Now match each adapter config against the regex
+    adapter_configs = []
+    for config_string_chunk in config_string_chunks:
+        match = re.match(ADAPTER_CONFIG_STRING_PATTERN, config_string_chunk.strip())
+        if not match or not match.group("name"):
+            raise ValueError(f"Invalid adapter config string format: '{config_string_chunk}'.")
+        name = match.group("name")
+        if kvs := match.group("kvs"):
+            # Replace "=" with ":" in key-value pairs for valid Python dict
+            kvs = re.sub(r"(\w+)=", r"'\1':", kvs)
+        else:
+            kvs = ""
+        # Now evaluate key-value pairs as Python dict
+        try:
+            config_kwargs = ast.literal_eval("{" + kvs + "}")
+        except:
+            raise ValueError(f"Invalid adapter configguration '{kvs}' in '{name}'.")
+        adapter_configs.append((name, config_kwargs))
+
+    return adapter_configs
+
+
 def resolve_adapter_config(config: Union[dict, str], local_map=None, try_loading_from_hub=True, **kwargs) -> dict:
     """
     Resolves a given adapter configuration specifier to a full configuration dictionary.
@@ -422,15 +453,36 @@ def resolve_adapter_config(config: Union[dict, str], local_map=None, try_loading
                 return loaded_config["config"]
             else:
                 return loaded_config
-    # now, try to find in hub index
+    # download hub index file
     if try_loading_from_hub:
         index_file = download_cached(ADAPTER_HUB_CONFIG_FILE, **kwargs)
         if not index_file:
             raise EnvironmentError("Unable to load adapter hub index file. The file might be temporarily unavailable.")
         with open(index_file, "r") as f:
             config_index = json.load(f)
-        if config in config_index:
-            return config_index[config]
+    # parse the config string
+    config_pairs = parse_adapter_config_string(config)
+    if len(config_pairs) > 0:
+        full_configs = []
+        for name, config_kwargs in config_pairs:
+            # first, look in local map
+            if local_map and name in local_map:
+                config_obj = local_map[name]
+                full_configs.append(config_obj.replace(**config_kwargs))
+            # now, try to find in hub index
+            elif try_loading_from_hub and name in config_index:
+                config_obj = config_index[name]
+                config_obj.update(**config_kwargs)
+                full_configs.append(config_obj)
+            else:
+                raise ValueError("Could not identify '{}' as a valid adapter configuration.".format(name))
+        # Case 1: only one config, return it directly
+        if len(full_configs) == 1:
+            return full_configs[0]
+        # Case 2: multiple configs, return a config union
+        elif len(full_configs) > 1:
+            return {"architecture": "union", "configs": full_configs}
+
     raise ValueError("Could not identify '{}' as a valid adapter configuration.".format(config))
 
 

--- a/src/transformers/adapters/utils.py
+++ b/src/transformers/adapters/utils.py
@@ -416,7 +416,7 @@ def parse_adapter_config_string(config_string: str) -> List[Tuple[str, dict]]:
         # Now evaluate key-value pairs as Python dict
         try:
             config_kwargs = ast.literal_eval("{" + kvs + "}")
-        except:
+        except Exception:
             raise ValueError(f"Invalid adapter configguration '{kvs}' in '{name}'.")
         adapter_configs.append((name, config_kwargs))
 

--- a/tests_adapters/test_adapter_config.py
+++ b/tests_adapters/test_adapter_config.py
@@ -12,6 +12,7 @@ from transformers import (
     ParallelConfig,
     PfeifferConfig,
     PrefixTuningConfig,
+    LoRAConfig,
 )
 from transformers.testing_utils import require_torch
 
@@ -88,3 +89,30 @@ class AdapterConfigTest(unittest.TestCase):
         for union, error_type in unions:
             with self.subTest(union=union):
                 self.assertRaises(error_type, ConfigUnion, *union)
+
+    def test_config_string_valid(self):
+        to_test = [
+            ("houlsby", HoulsbyConfig()),
+            ("pfeiffer[reduction_factor=2, leave_out=[11]]", PfeifferConfig(reduction_factor=2, leave_out=[11])),
+            ("parallel[reduction_factor={'0': 8, '1': 8, 'default': 16}]", ParallelConfig(reduction_factor={"0": 8, "1": 8, "default": 16})),
+            ("prefix_tuning[prefix_length=30, flat=True]", PrefixTuningConfig(prefix_length=30, flat=True)),
+            ("lora[r=200,alpha=8]", LoRAConfig(r=200, alpha=8)),
+            ("prefix_tuning|parallel", ConfigUnion(PrefixTuningConfig(), ParallelConfig())),
+            ("lora[attn_matrices=['k', 'v']]", LoRAConfig(attn_matrices=["k", "v"])),
+            ("lora[use_gating=True]|prefix_tuning[use_gating=True]|pfeiffer[use_gating=True]", ConfigUnion(LoRAConfig(use_gating=True), PrefixTuningConfig(use_gating=True), PfeifferConfig(use_gating=True))),
+        ]
+        for config_str, config in to_test:
+            with self.subTest(config_str=config_str):
+                config_new = AdapterConfig.load(config_str)
+                self.assertEqual(config, config_new)
+
+    def test_config_string_invalid(self):
+        to_test = [
+            ("pfeiffer[invalid_key=2]", TypeError),
+            ("lora[r=8]|invalid_name", ValueError),
+            ("prefix_tuning[flat=True", ValueError),
+            ("houlsby[reduction_factor=dict(default=1)]", ValueError),
+        ]
+        for config_str, error_type in to_test:
+            with self.subTest(config_str=config_str):
+                self.assertRaises(error_type, AdapterConfig.load, config_str)


### PR DESCRIPTION
### Configuration strings
This PR adds the possibility to use flexible adapter configuration strings which allow specifying custom config attributes.
Examples:
- Set config attributes: `model.add_adapter("name", config="parallel[reduction_factor=2]")`
- Config union `model.add_adapter("name", config="prefix_tuning|parallel")`
- more examples: https://github.com/calpt/adapter-transformers/blob/8df62b9de2a8ab51115b191aca35b2fb53c96539/tests_adapters/test_adapter_config.py#L95-L102

Documentation: https://github.com/calpt/adapter-transformers/blob/8df62b9de2a8ab51115b191aca35b2fb53c96539/adapter_docs/overview.md

Configuration strings can allow passing complex configurations e.g. via command line.

### Documentation restructuring

The adapter method documentation is now split into three pages:
- Overview and Configuration: introduction, table, configuration
- Adapter Methods
- Method Combinations
