### PR TITLE
Add adapter support to CLIP

### DIFF
--- a/adapter_docs/classes/models/clip.rst
+++ b/adapter_docs/classes/models/clip.rst
@@ -1,0 +1,50 @@
+CLIP
+=====
+
+.. note::
+    Adapter implementation notes:
+        - CLIP consists of two separate Transformer encoder models, a ViT-style Transformer for visual features and a language model for textual features. Both encoders can be fitted with adapters. As usual, the ``leave_out`` parameter can be used to specify the layers in which adapters should be added. For CLIP, layer IDs are counted globally across both encoders, starting from the text encoder. I.e., for a CLIP model with 12 layers in each Transformer encoder, the text encoder will have IDs 0-11 and the vision encoder will have IDs 12-23.
+        - As CLIP does not come with pre-supported task-specific prediction heads, there is currently no ``CLIPAdapterModel`` class. Use ``CLIPModel`` instead.
+
+The CLIP model was proposed in `Learning Transferable Visual Models From Natural Language Supervision <https://arxiv.org/abs/2103.00020>`_ by Alec Radford, Jong Wook Kim, Chris Hallacy, Aditya Ramesh, Gabriel Goh,
+Sandhini Agarwal, Girish Sastry, Amanda Askell, Pamela Mishkin, Jack Clark, Gretchen Krueger, Ilya Sutskever. CLIP
+(Contrastive Language-Image Pre-Training) is a neural network trained on a variety of (image, text) pairs. It can be
+instructed in natural language to predict the most relevant text snippet, given an image, without directly optimizing
+for the task, similarly to the zero-shot capabilities of GPT-2 and 3.
+
+The abstract from the paper is the following:
+
+*State-of-the-art computer vision systems are trained to predict a fixed set of predetermined object categories. This
+restricted form of supervision limits their generality and usability since additional labeled data is needed to specify
+any other visual concept. Learning directly from raw text about images is a promising alternative which leverages a
+much broader source of supervision. We demonstrate that the simple pre-training task of predicting which caption goes
+with which image is an efficient and scalable way to learn SOTA image representations from scratch on a dataset of 400
+million (image, text) pairs collected from the internet. After pre-training, natural language is used to reference
+learned visual concepts (or describe new ones) enabling zero-shot transfer of the model to downstream tasks. We study
+the performance of this approach by benchmarking on over 30 different existing computer vision datasets, spanning tasks
+such as OCR, action recognition in videos, geo-localization, and many types of fine-grained object classification. The
+model transfers non-trivially to most tasks and is often competitive with a fully supervised baseline without the need
+for any dataset specific training. For instance, we match the accuracy of the original ResNet-50 on ImageNet zero-shot
+without needing to use any of the 1.28 million training examples it was trained on. We release our code and pre-trained
+model weights at this https URL.*
+
+CLIPTextModel
+~~~~~~~~~~~~~
+
+.. autoclass:: transformers.CLIPTextModel
+    :members:
+    :inherited-members: CLIPPreTrainedModel
+
+CLIPVisionModel
+~~~~~~~~~~~~~~~
+
+.. autoclass:: transformers.CLIPVisionModel
+    :members:
+    :inherited-members: CLIPPreTrainedModel
+
+CLIPModel
+~~~~~~~~~
+
+.. autoclass:: transformers.CLIPModel
+    :members:
+    :inherited-members: CLIPPreTrainedModel

--- a/adapter_docs/index.rst
+++ b/adapter_docs/index.rst
@@ -53,6 +53,7 @@ Currently, we support the PyTorch versions of all models as listed on the `Model
    classes/models/bart
    classes/models/beit
    classes/models/bert
+   classes/models/clip
    classes/models/deberta
    classes/models/deberta_v2
    classes/models/distilbert

--- a/adapter_docs/model_overview.md
+++ b/adapter_docs/model_overview.md
@@ -15,6 +15,7 @@ The table below further shows which model architectures support which adaptation
 | [BART](classes/models/bart.html)        | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [BEIT](classes/models/beit.html)        | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |
 | [BERT](classes/models/bert.html)        | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [CLIP](classes/models/clip.html)        | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |
 | [DeBERTa](classes/models/deberta.html) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [DeBERTa-v2](classes/models/debertaV2.html) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [DistilBERT](classes/models/distilbert.html) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/src/transformers/adapters/__init__.py
+++ b/src/transformers/adapters/__init__.py
@@ -82,6 +82,7 @@ _import_structure = {
     "model_mixin": [
         "EmbeddingAdaptersMixin",
         "InvertibleAdaptersMixin",
+        "InvertibleAdaptersWrapperMixin",
         "ModelAdaptersMixin",
         "ModelWithHeadsAdaptersMixin",
     ],
@@ -200,6 +201,7 @@ if TYPE_CHECKING:
     from .model_mixin import (
         EmbeddingAdaptersMixin,
         InvertibleAdaptersMixin,
+        InvertibleAdaptersWrapperMixin,
         ModelAdaptersMixin,
         ModelWithHeadsAdaptersMixin,
     )

--- a/src/transformers/adapters/mixins/bart.py
+++ b/src/transformers/adapters/mixins/bart.py
@@ -33,6 +33,7 @@ class BartDecoderLayerAdaptersMixin(BartEncoderLayerAdaptersMixin):
 
 class BartModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersWrapperMixin, ModelAdaptersMixin):
     """Adds adapters to the BartModel class."""
+
     invertible_adapters_base_name = "encoder"
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:

--- a/src/transformers/adapters/mixins/bart.py
+++ b/src/transformers/adapters/mixins/bart.py
@@ -6,7 +6,7 @@ from ..layer import AdapterLayer
 from ..model_mixin import (
     EmbeddingAdaptersMixin,
     EmbeddingAdaptersWrapperMixin,
-    InvertibleAdaptersMixin,
+    InvertibleAdaptersWrapperMixin,
     ModelAdaptersMixin,
     ModelWithHeadsAdaptersMixin,
 )
@@ -31,8 +31,9 @@ class BartDecoderLayerAdaptersMixin(BartEncoderLayerAdaptersMixin):
         self.cross_attention_adapters._init_adapter_modules()
 
 
-class BartModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelAdaptersMixin):
+class BartModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersWrapperMixin, ModelAdaptersMixin):
     """Adds adapters to the BartModel class."""
+    invertible_adapters_base_name = "encoder"
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
         if hasattr(self, "encoder"):
@@ -43,17 +44,6 @@ class BartModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, Mo
         else:
             for i, layer in enumerate(self.decoder.layers):
                 yield i, layer
-
-    def _init_adapter_modules(self):
-        if hasattr(self, "encoder"):
-            # In BART, the invertible adapters are implemented by the encoder module.
-            # Therefore, relay mixin calls to the encoder here.
-            self.invertible_adapters = self.encoder.invertible_adapters
-            self.add_invertible_adapter = self.encoder.add_invertible_adapter
-            self.get_invertible_adapter = self.encoder.get_invertible_adapter
-            self.enable_invertible_adapters = self.encoder.enable_invertible_adapters
-            self.invertible_adapters_forward = self.encoder.invertible_adapters_forward
-        super()._init_adapter_modules()
 
 
 class BartModelWithHeadsAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdaptersMixin):

--- a/src/transformers/adapters/mixins/clip.py
+++ b/src/transformers/adapters/mixins/clip.py
@@ -7,7 +7,7 @@ from ..layer import AdapterLayer
 from ..model_mixin import (
     EmbeddingAdaptersMixin,
     EmbeddingAdaptersWrapperMixin,
-    InvertibleAdaptersMixin,
+    InvertibleAdaptersWrapperMixin,
     ModelAdaptersMixin,
 )
 
@@ -22,16 +22,9 @@ class CLIPEncoderLayerAdaptersMixin:
         self.output_adapters._init_adapter_modules()
 
 
-class CLIPTextModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelAdaptersMixin):
+class CLIPTextModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersWrapperMixin, ModelAdaptersMixin):
     """Adds adapters to the CLIPTextModel class."""
-
-    def _init_adapter_modules(self):
-        self.invertible_adapters = self.text_model.invertible_adapters
-        self.add_invertible_adapter = self.text_model.add_invertible_adapter
-        self.get_invertible_adapter = self.text_model.get_invertible_adapter
-        self.enable_invertible_adapters = self.text_model.enable_invertible_adapters
-        self.invertible_adapters_forward = self.text_model.invertible_adapters_forward
-        super()._init_adapter_modules()
+    invertible_adapters_base_name = "text_model"
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
         for i, layer in enumerate(self.text_model.encoder.layers):
@@ -46,16 +39,9 @@ class CLIPVisionModelAdaptersMixin(ModelAdaptersMixin):
             yield i, layer
 
 
-class CLIPModelAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelAdaptersMixin):
+class CLIPModelAdaptersMixin(EmbeddingAdaptersWrapperMixin, InvertibleAdaptersWrapperMixin, ModelAdaptersMixin):
     """Adds adapters to the CLIPModel class."""
-
-    def _init_adapter_modules(self):
-        self.invertible_adapters = self.text_model.invertible_adapters
-        self.add_invertible_adapter = self.text_model.add_invertible_adapter
-        self.get_invertible_adapter = self.text_model.get_invertible_adapter
-        self.enable_invertible_adapters = self.text_model.enable_invertible_adapters
-        self.invertible_adapters_forward = self.text_model.invertible_adapters_forward
-        super()._init_adapter_modules()
+    invertible_adapters_base_name = "text_model"
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
         for i, layer in enumerate(self.text_model.encoder.layers):

--- a/src/transformers/adapters/mixins/clip.py
+++ b/src/transformers/adapters/mixins/clip.py
@@ -2,7 +2,6 @@ from typing import Iterable, Tuple
 
 import torch.nn as nn
 
-
 from ..layer import AdapterLayer
 from ..model_mixin import (
     EmbeddingAdaptersMixin,
@@ -24,6 +23,7 @@ class CLIPEncoderLayerAdaptersMixin:
 
 class CLIPTextModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersWrapperMixin, ModelAdaptersMixin):
     """Adds adapters to the CLIPTextModel class."""
+
     invertible_adapters_base_name = "text_model"
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
@@ -41,6 +41,7 @@ class CLIPVisionModelAdaptersMixin(ModelAdaptersMixin):
 
 class CLIPModelAdaptersMixin(EmbeddingAdaptersWrapperMixin, InvertibleAdaptersWrapperMixin, ModelAdaptersMixin):
     """Adds adapters to the CLIPModel class."""
+
     invertible_adapters_base_name = "text_model"
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:

--- a/src/transformers/adapters/mixins/clip.py
+++ b/src/transformers/adapters/mixins/clip.py
@@ -27,7 +27,7 @@ class CLIPTextModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin
     """Adds adapters to the CLIPTextModel class."""
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
-        for i, layer in enumerate(self.text_model.transformer.layers):
+        for i, layer in enumerate(self.text_model.encoder.layers):
             yield i, layer
 
 
@@ -35,7 +35,7 @@ class CLIPVisionModelAdaptersMixin(ModelAdaptersMixin):
     """Adds adapters to the a CLIPVisionModel class."""
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
-        for i, layer in enumerate(self.vision_model.transformer.layers):
+        for i, layer in enumerate(self.vision_model.encoder.layers):
             yield i, layer
 
 
@@ -51,7 +51,7 @@ class CLIPModelAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdapte
         super()._init_adapter_modules()
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
-        for i, layer in enumerate(self.text_model.transformer.layers):
+        for i, layer in enumerate(self.text_model.encoder.layers):
             yield i, layer
-        for i, layer in enumerate(self.vision_model.transformer.layers):
+        for i, layer in enumerate(self.vision_model.encoder.layers):
             yield i, layer

--- a/src/transformers/adapters/mixins/clip.py
+++ b/src/transformers/adapters/mixins/clip.py
@@ -1,0 +1,57 @@
+from typing import Iterable, Tuple
+
+import torch.nn as nn
+
+
+from ..layer import AdapterLayer
+from ..model_mixin import (
+    EmbeddingAdaptersMixin,
+    EmbeddingAdaptersWrapperMixin,
+    InvertibleAdaptersMixin,
+    ModelAdaptersMixin,
+    ModelWithHeadsAdaptersMixin,
+)
+
+
+class CLIPEncoderLayerAdaptersMixin:
+    """Adds adapters to the CLIPEncoderLayer module of CLIP."""
+
+    def _init_adapter_modules(self):
+        self.attention_adapters = AdapterLayer("mh_adapter", self.config)
+        self.output_adapters = AdapterLayer("output_adapter", self.config)
+        self.attention_adapters._init_adapter_modules()
+        self.output_adapters._init_adapter_modules()
+
+
+class CLIPTextModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelAdaptersMixin):
+    """Adds adapters to the CLIPTextModel class."""
+
+    def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
+        for i, layer in enumerate(self.text_model.transformer.layers):
+            yield i, layer
+
+
+class CLIPVisionModelAdaptersMixin(ModelAdaptersMixin):
+    """Adds adapters to the a CLIPVisionModel class."""
+
+    def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
+        for i, layer in enumerate(self.vision_model.transformer.layers):
+            yield i, layer
+
+
+class CLIPModelAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdaptersMixin):
+    """Adds adapters to the CLIPModel class."""
+
+    def _init_adapter_modules(self):
+        self.invertible_adapters = self.text_model.invertible_adapters
+        self.add_invertible_adapter = self.text_model.add_invertible_adapter
+        self.get_invertible_adapter = self.text_model.get_invertible_adapter
+        self.enable_invertible_adapters = self.text_model.enable_invertible_adapters
+        self.invertible_adapters_forward = self.text_model.invertible_adapters_forward
+        super()._init_adapter_modules()
+
+    def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
+        for i, layer in enumerate(self.text_model.transformer.layers):
+            yield i, layer
+        for i, layer in enumerate(self.vision_model.transformer.layers):
+            yield i, layer

--- a/src/transformers/adapters/mixins/clip.py
+++ b/src/transformers/adapters/mixins/clip.py
@@ -9,7 +9,6 @@ from ..model_mixin import (
     EmbeddingAdaptersWrapperMixin,
     InvertibleAdaptersMixin,
     ModelAdaptersMixin,
-    ModelWithHeadsAdaptersMixin,
 )
 
 
@@ -26,6 +25,14 @@ class CLIPEncoderLayerAdaptersMixin:
 class CLIPTextModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelAdaptersMixin):
     """Adds adapters to the CLIPTextModel class."""
 
+    def _init_adapter_modules(self):
+        self.invertible_adapters = self.text_model.invertible_adapters
+        self.add_invertible_adapter = self.text_model.add_invertible_adapter
+        self.get_invertible_adapter = self.text_model.get_invertible_adapter
+        self.enable_invertible_adapters = self.text_model.enable_invertible_adapters
+        self.invertible_adapters_forward = self.text_model.invertible_adapters_forward
+        super()._init_adapter_modules()
+
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
         for i, layer in enumerate(self.text_model.encoder.layers):
             yield i, layer
@@ -39,7 +46,7 @@ class CLIPVisionModelAdaptersMixin(ModelAdaptersMixin):
             yield i, layer
 
 
-class CLIPModelAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdaptersMixin):
+class CLIPModelAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelAdaptersMixin):
     """Adds adapters to the CLIPModel class."""
 
     def _init_adapter_modules(self):
@@ -53,5 +60,5 @@ class CLIPModelAdaptersMixin(EmbeddingAdaptersWrapperMixin, ModelWithHeadsAdapte
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
         for i, layer in enumerate(self.text_model.encoder.layers):
             yield i, layer
-        for i, layer in enumerate(self.vision_model.encoder.layers):
+        for i, layer in enumerate(self.vision_model.encoder.layers, start=len(self.text_model.encoder.layers)):
             yield i, layer

--- a/src/transformers/adapters/mixins/t5.py
+++ b/src/transformers/adapters/mixins/t5.py
@@ -28,6 +28,7 @@ class T5FFLayerAdaptersMixin(AdapterLayer):
 
 class T5ModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersWrapperMixin, ModelAdaptersMixin):
     """Adds adapters to the T5Model class."""
+
     invertible_adapters_base_name = "encoder"
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:

--- a/src/transformers/adapters/mixins/t5.py
+++ b/src/transformers/adapters/mixins/t5.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 from ..layer import AdapterLayer
 from ..model_mixin import (
     EmbeddingAdaptersMixin,
-    InvertibleAdaptersMixin,
+    InvertibleAdaptersWrapperMixin,
     ModelAdaptersMixin,
     ModelWithHeadsAdaptersMixin,
 )
@@ -26,8 +26,9 @@ class T5FFLayerAdaptersMixin(AdapterLayer):
         super().__init__("output_adapter", None)
 
 
-class T5ModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelAdaptersMixin):
+class T5ModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersWrapperMixin, ModelAdaptersMixin):
     """Adds adapters to the T5Model class."""
+    invertible_adapters_base_name = "encoder"
 
     def iter_layers(self) -> Iterable[Tuple[int, nn.Module]]:
         global_i = 0
@@ -38,18 +39,6 @@ class T5ModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, Mode
         if hasattr(self, "decoder"):
             for i, layer in enumerate(self.decoder.block, start=global_i):
                 yield i, layer
-
-    def _init_adapter_modules(self):
-        if hasattr(self, "encoder"):
-            # In T5, the invertible adapters are implemented by the encoder module.
-            # Therefore, relay mixin calls to the encoder here.
-            self.invertible_adapters = self.encoder.invertible_adapters
-            self.add_invertible_adapter = self.encoder.add_invertible_adapter
-            self.get_invertible_adapter = self.encoder.get_invertible_adapter
-            self.enable_invertible_adapters = self.encoder.enable_invertible_adapters
-            self.invertible_adapters_forward = self.encoder.invertible_adapters_forward
-            self.delete_invertible_adapter = self.encoder.delete_invertible_adapter
-        super()._init_adapter_modules()
 
 
 # EmbeddingAdaptersWrapperMixin not required here as base and heads model are identical

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -103,6 +103,54 @@ class InvertibleAdaptersMixin:
         return hidden_states
 
 
+class InvertibleAdaptersWrapperMixin:
+    """
+    Mixin for Transformer models supporting invertible adapters in a child module.
+    When applying this mixin, set `invertible_adapters_base_name` to the name of the child module that includes `InvertibleAdaptersMixin`.
+    """
+
+    invertible_adapters_base_name = ""
+
+    @property
+    def invertible_adapters_base(self):
+        return getattr(self, self.invertible_adapters_base_name, None)
+
+    @property
+    def invertible_adapters(self):
+        if self.invertible_adapters_base is not None:
+            return self.invertible_adapters_base.invertible_adapters
+        return None
+
+    def add_invertible_adapter(self, adapter_name: str):
+        """
+        Adds an invertible adapter module for the adapter with the given name. If the given adapter does not specify an
+        invertible adapter config, this method does nothing.
+
+        Args:
+            adapter_name (str): The name of the adapter for which to add an invertible adapter module.
+        """
+        if self.invertible_adapters_base is not None:
+            self.invertible_adapters_base.add_invertible_adapter(adapter_name)
+
+    def delete_invertible_adapter(self, adapter_name: str):
+        if self.invertible_adapters_base is not None:
+            self.invertible_adapters_base.delete_invertible_adapter(adapter_name)
+
+    def get_invertible_adapter(self):
+        if self.invertible_adapters_base is not None:
+            return self.invertible_adapters_base.get_invertible_adapter()
+        return None
+
+    def enable_invertible_adapters(self, adapter_names):
+        if self.invertible_adapters_base is not None:
+            self.invertible_adapters_base.enable_invertible_adapters(adapter_names)
+
+    def invertible_adapters_forward(self, hidden_states, rev=False):
+        if self.invertible_adapters_base is not None:
+            return self.invertible_adapters_base.invertible_adapters_forward(hidden_states, rev=rev)
+        return hidden_states
+
+
 class EmbeddingAdaptersMixin:
     """Mixin for Transformer models adding support for dynamically switching embeddings."""
 
@@ -331,7 +379,7 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
                 for param in self.base_model.shared_parameters[adapter_name].values():
                     param.requires_grad = True
 
-        if isinstance(self, InvertibleAdaptersMixin):
+        if isinstance(self, InvertibleAdaptersMixin) or isinstance(self, InvertibleAdaptersWrapperMixin):
             self.enable_invertible_adapters(adapter_setup.flatten())
         # use the adapters to be trained by default in every forward pass
         self.set_active_adapters(adapter_setup)
@@ -447,7 +495,7 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
         for module in self.modules():
             if isinstance(module, PrefixTuningPool):
                 module.confirm_prefix(adapter_name)
-        if isinstance(self, InvertibleAdaptersMixin):
+        if isinstance(self, InvertibleAdaptersMixin) or isinstance(self, InvertibleAdaptersWrapperMixin):
             self.add_invertible_adapter(adapter_name)
 
     def add_fusion(self, adapter_names: Union[Fuse, list], adapter_fusion_config=None, override_kwargs=None):
@@ -517,7 +565,7 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
         # PHM Layer
         if adapter_name in self.base_model.shared_parameters:
             del self.base_model.shared_parameters[adapter_name]
-        if isinstance(self, InvertibleAdaptersMixin):
+        if isinstance(self, InvertibleAdaptersMixin) or isinstance(self, InvertibleAdaptersWrapperMixin):
             self.delete_invertible_adapter(adapter_name)
         # Reset active adapters if this was the only active adapter
         if self.active_adapters == Stack(adapter_name):
@@ -828,7 +876,11 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
         # global weights are saved at index -1
         if name in self.base_model.shared_parameters:
             destination[-1]["shared"] = self.base_model.shared_parameters[name]
-        if isinstance(self, InvertibleAdaptersMixin) and name in self.invertible_adapters:
+        if (
+            isinstance(self, InvertibleAdaptersMixin)
+            or isinstance(self, InvertibleAdaptersWrapperMixin)
+            and name in self.invertible_adapters
+        ):
             destination[-1]["invertible"] = self.invertible_adapters[name]
 
         # use a custom index to ensure numbering is from 0 to N layers

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -877,10 +877,8 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
         if name in self.base_model.shared_parameters:
             destination[-1]["shared"] = self.base_model.shared_parameters[name]
         if (
-            isinstance(self, InvertibleAdaptersMixin)
-            or isinstance(self, InvertibleAdaptersWrapperMixin)
-            and name in self.invertible_adapters
-        ):
+            isinstance(self, InvertibleAdaptersMixin) or isinstance(self, InvertibleAdaptersWrapperMixin)
+        ) and name in self.invertible_adapters:
             destination[-1]["invertible"] = self.invertible_adapters[name]
 
         # use a custom index to ensure numbering is from 0 to N layers

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -39,7 +39,8 @@ class InvertibleAdaptersMixin:
         self.invertible_adapters = nn.ModuleDict(dict())
 
         # Make sure config is wrapped
-        self.config = wrap_config(self.config)
+        if hasattr(self, "config"):
+            self.config = wrap_config(self.config)
 
     def add_invertible_adapter(self, adapter_name: str):
         """

--- a/src/transformers/adapters/model_mixin.py
+++ b/src/transformers/adapters/model_mixin.py
@@ -105,8 +105,8 @@ class InvertibleAdaptersMixin:
 
 class InvertibleAdaptersWrapperMixin:
     """
-    Mixin for Transformer models supporting invertible adapters in a child module.
-    When applying this mixin, set `invertible_adapters_base_name` to the name of the child module that includes `InvertibleAdaptersMixin`.
+    Mixin for Transformer models supporting invertible adapters in a child module. When applying this mixin, set
+    `invertible_adapters_base_name` to the name of the child module that includes `InvertibleAdaptersMixin`.
     """
 
     invertible_adapters_base_name = ""

--- a/src/transformers/adapters/wrappers/configuration.py
+++ b/src/transformers/adapters/wrappers/configuration.py
@@ -1,3 +1,5 @@
+import copy
+
 from ...configuration_utils import PretrainedConfig
 from ...models.clip.configuration_clip import CLIPConfig
 from ...models.encoder_decoder.configuration_encoder_decoder import EncoderDecoderConfig
@@ -77,6 +79,8 @@ def wrap_config(config: PretrainedConfig) -> PretrainedConfig:
     for fusion_adapter_names in fusion_models:
         config.adapters.add_fusion(fusion_adapter_names, config=fusion_config)
 
+    # Make sure each class has its own attribute_map
+    type(config).attribute_map = copy.deepcopy(type(config).attribute_map)
     # Ensure missing keys are in class
     if config.model_type in CONFIG_CLASS_KEYS_MAPPING:
         for key, value in CONFIG_CLASS_KEYS_MAPPING[config.model_type].items():

--- a/src/transformers/adapters/wrappers/configuration.py
+++ b/src/transformers/adapters/wrappers/configuration.py
@@ -1,5 +1,6 @@
 from ...configuration_utils import PretrainedConfig
 from ...models.encoder_decoder.configuration_encoder_decoder import EncoderDecoderConfig
+from ...models.clip.configuration_clip import CLIPConfig
 from ..configuration import ModelAdaptersConfig
 
 
@@ -12,6 +13,14 @@ CONFIG_CLASS_KEYS_MAPPING = {
     },
     "beit": {},
     "bert": {},
+    "clip_vision_model": {
+        "hidden_dropout_prob": "dropout",
+        "attention_probs_dropout_prob": "attention_dropout",
+    },
+    "clip_text_model": {
+        "hidden_dropout_prob": "dropout",
+        "attention_probs_dropout_prob": "attention_dropout",
+    },
     "distilbert": {
         "hidden_dropout_prob": "dropout",
         "attention_probs_dropout_prob": "attention_dropout",
@@ -84,7 +93,11 @@ def wrap_config(config: PretrainedConfig) -> PretrainedConfig:
         wrap_config(config.decoder)
         config.decoder.adapters = config.encoder.adapters
         config.adapters = config.encoder.adapters
-
+    elif isinstance(config, CLIPConfig):
+        wrap_config(config.vision_config)
+        wrap_config(config.text_config)
+        config.vision_config.adapters = config.adapters
+        config.text_config.adapters = config.adapters
     config.is_adaptable = True
 
     return config

--- a/src/transformers/adapters/wrappers/configuration.py
+++ b/src/transformers/adapters/wrappers/configuration.py
@@ -1,6 +1,6 @@
 from ...configuration_utils import PretrainedConfig
-from ...models.encoder_decoder.configuration_encoder_decoder import EncoderDecoderConfig
 from ...models.clip.configuration_clip import CLIPConfig
+from ...models.encoder_decoder.configuration_encoder_decoder import EncoderDecoderConfig
 from ..configuration import ModelAdaptersConfig
 
 

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -347,6 +347,9 @@ class CLIPConfig(PretrainedConfig):
         output["text_config"] = self.text_config.to_dict()
         output["vision_config"] = self.vision_config.to_dict()
         output["model_type"] = self.__class__.model_type
+
+        self.adapters_to_dict(output)
+
         return output
 
 

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -349,6 +349,11 @@ class CLIPConfig(PretrainedConfig):
         output["model_type"] = self.__class__.model_type
 
         self.adapters_to_dict(output)
+        # Remove adapters config from sub-configs
+        if "adapters" in output["text_config"]:
+            del output["text_config"]["adapters"]
+        if "adapters" in output["vision_config"]:
+            del output["vision_config"]["adapters"]
 
         return output
 

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -924,6 +924,7 @@ class CLIPModel(CLIPModelAdaptersMixin, CLIPPreTrainedModel):
         self.post_init()
 
     @add_start_docstrings_to_model_forward(CLIP_TEXT_INPUTS_DOCSTRING)
+    @ForwardContext.wrap
     def get_text_features(
         self,
         input_ids: Optional[torch.Tensor] = None,
@@ -971,6 +972,7 @@ class CLIPModel(CLIPModelAdaptersMixin, CLIPPreTrainedModel):
         return text_features
 
     @add_start_docstrings_to_model_forward(CLIP_VISION_INPUTS_DOCSTRING)
+    @ForwardContext.wrap
     def get_image_features(
         self,
         pixel_values: Optional[torch.FloatTensor] = None,

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -23,6 +23,17 @@ import torch.utils.checkpoint
 from torch import nn
 
 from ...activations import ACT2FN
+from ...adapters.composition import adjust_tensors_for_parallel
+from ...adapters.context import ForwardContext
+from ...adapters.lora import Linear as LoRALinear
+from ...adapters.mixins.clip import (
+    CLIPEncoderLayerAdaptersMixin,
+    CLIPTextModelAdaptersMixin,
+    CLIPVisionModelAdaptersMixin,
+    CLIPModelAdaptersMixin,
+)
+from ...adapters.model_mixin import InvertibleAdaptersMixin
+from ...adapters.prefix_tuning import PrefixTuningShim
 from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
 from ...modeling_utils import PreTrainedModel
 from ...utils import (
@@ -187,10 +198,12 @@ class CLIPAttention(nn.Module):
         self.scale = self.head_dim**-0.5
         self.dropout = config.attention_dropout
 
-        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim)
-        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim)
-        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.k_proj = LoRALinear(self.embed_dim, self.embed_dim, "selfattn", config, attn_key="k")
+        self.v_proj = LoRALinear(self.embed_dim, self.embed_dim, "selfattn", config, attn_key="v")
+        self.q_proj = LoRALinear(self.embed_dim, self.embed_dim, "selfattn", config, attn_key="q")
         self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
+
+        self.prefix_tuning = PrefixTuningShim("self_prefix", config)
 
     def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
         return tensor.view(bsz, seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
@@ -213,6 +226,11 @@ class CLIPAttention(nn.Module):
 
         proj_shape = (bsz * self.num_heads, -1, self.head_dim)
         query_states = self._shape(query_states, tgt_len, bsz).view(*proj_shape)
+
+        key_states, value_states, attention_mask = self.prefix_tuning(
+            key_states, value_states, hidden_states, attention_mask
+        )
+
         key_states = key_states.view(*proj_shape)
         value_states = value_states.view(*proj_shape)
 
@@ -279,8 +297,8 @@ class CLIPMLP(nn.Module):
         super().__init__()
         self.config = config
         self.activation_fn = ACT2FN[config.hidden_act]
-        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
-        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+        self.fc1 = LoRALinear(config.hidden_size, config.intermediate_size, "intermediate", config)
+        self.fc2 = LoRALinear(config.intermediate_size, config.hidden_size, "output", config)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         hidden_states = self.fc1(hidden_states)
@@ -289,14 +307,18 @@ class CLIPMLP(nn.Module):
         return hidden_states
 
 
-class CLIPEncoderLayer(nn.Module):
+class CLIPEncoderLayer(CLIPEncoderLayerAdaptersMixin, nn.Module):
     def __init__(self, config: CLIPConfig):
         super().__init__()
+        self.config = config
+
         self.embed_dim = config.hidden_size
         self.self_attn = CLIPAttention(config)
         self.layer_norm1 = nn.LayerNorm(self.embed_dim)
         self.mlp = CLIPMLP(config)
         self.layer_norm2 = nn.LayerNorm(self.embed_dim)
+
+        self._init_adapter_modules()
 
     def forward(
         self,
@@ -324,12 +346,12 @@ class CLIPEncoderLayer(nn.Module):
             causal_attention_mask=causal_attention_mask,
             output_attentions=output_attentions,
         )
-        hidden_states = residual + hidden_states
+        hidden_states = self.attention_adapters(hidden_states, residual, layer_norm=None)
 
         residual = hidden_states
         hidden_states = self.layer_norm2(hidden_states)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
+        hidden_states = self.output_adapters(hidden_states, residual, layer_norm=None)
 
         outputs = (hidden_states,)
 
@@ -583,6 +605,7 @@ class CLIPEncoder(nn.Module):
                 )
 
             hidden_states = layer_outputs[0]
+            (attention_mask,) = adjust_tensors_for_parallel(hidden_states, attention_mask)
 
             if output_attentions:
                 all_attentions = all_attentions + (layer_outputs[1],)
@@ -597,7 +620,7 @@ class CLIPEncoder(nn.Module):
         )
 
 
-class CLIPTextTransformer(nn.Module):
+class CLIPTextTransformer(InvertibleAdaptersMixin, nn.Module):
     def __init__(self, config: CLIPTextConfig):
         super().__init__()
         self.config = config
@@ -634,6 +657,8 @@ class CLIPTextTransformer(nn.Module):
         input_ids = input_ids.view(-1, input_shape[-1])
 
         hidden_states = self.embeddings(input_ids=input_ids, position_ids=position_ids)
+
+        hidden_states = self.invertible_adapters_forward(hidden_states)
 
         bsz, seq_len = input_shape
         # CLIP's text model uses causal mask, prepare it here.
@@ -685,7 +710,7 @@ class CLIPTextTransformer(nn.Module):
         return mask
 
 
-class CLIPTextModel(CLIPPreTrainedModel):
+class CLIPTextModel(CLIPTextModelAdaptersMixin, CLIPPreTrainedModel):
     config_class = CLIPTextConfig
 
     _no_split_modules = ["CLIPEncoderLayer"]
@@ -693,6 +718,8 @@ class CLIPTextModel(CLIPPreTrainedModel):
     def __init__(self, config: CLIPTextConfig):
         super().__init__(config)
         self.text_model = CLIPTextTransformer(config)
+
+        self._init_adapter_modules()
         # Initialize weights and apply final processing
         self.post_init()
 
@@ -704,6 +731,7 @@ class CLIPTextModel(CLIPPreTrainedModel):
 
     @add_start_docstrings_to_model_forward(CLIP_TEXT_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=BaseModelOutputWithPooling, config_class=CLIPTextConfig)
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids: Optional[torch.Tensor] = None,
@@ -798,13 +826,15 @@ class CLIPVisionTransformer(nn.Module):
         )
 
 
-class CLIPVisionModel(CLIPPreTrainedModel):
+class CLIPVisionModel(CLIPVisionModelAdaptersMixin, CLIPPreTrainedModel):
     config_class = CLIPVisionConfig
     main_input_name = "pixel_values"
 
     def __init__(self, config: CLIPVisionConfig):
         super().__init__(config)
         self.vision_model = CLIPVisionTransformer(config)
+
+        self._init_adapter_modules()
         # Initialize weights and apply final processing
         self.post_init()
 
@@ -813,6 +843,7 @@ class CLIPVisionModel(CLIPPreTrainedModel):
 
     @add_start_docstrings_to_model_forward(CLIP_VISION_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=BaseModelOutputWithPooling, config_class=CLIPVisionConfig)
+    @ForwardContext.wrap
     def forward(
         self,
         pixel_values: Optional[torch.FloatTensor] = None,
@@ -851,7 +882,7 @@ class CLIPVisionModel(CLIPPreTrainedModel):
 
 
 @add_start_docstrings(CLIP_START_DOCSTRING)
-class CLIPModel(CLIPPreTrainedModel):
+class CLIPModel(CLIPModelAdaptersMixin, CLIPPreTrainedModel):
     config_class = CLIPConfig
 
     def __init__(self, config: CLIPConfig):

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -28,13 +28,13 @@ from ...adapters.context import ForwardContext
 from ...adapters.lora import Linear as LoRALinear
 from ...adapters.mixins.clip import (
     CLIPEncoderLayerAdaptersMixin,
+    CLIPModelAdaptersMixin,
     CLIPTextModelAdaptersMixin,
     CLIPVisionModelAdaptersMixin,
-    CLIPModelAdaptersMixin,
 )
 from ...adapters.model_mixin import InvertibleAdaptersMixin
-from ...adapters.wrappers.configuration import wrap_config
 from ...adapters.prefix_tuning import PrefixTuningShim
+from ...adapters.wrappers.configuration import wrap_config
 from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
 from ...modeling_utils import PreTrainedModel
 from ...utils import (

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -33,6 +33,7 @@ from ...adapters.mixins.clip import (
     CLIPModelAdaptersMixin,
 )
 from ...adapters.model_mixin import InvertibleAdaptersMixin
+from ...adapters.wrappers.configuration import wrap_config
 from ...adapters.prefix_tuning import PrefixTuningShim
 from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
 from ...modeling_utils import PreTrainedModel
@@ -623,7 +624,7 @@ class CLIPEncoder(nn.Module):
 class CLIPTextTransformer(InvertibleAdaptersMixin, nn.Module):
     def __init__(self, config: CLIPTextConfig):
         super().__init__()
-        self.config = config
+        self.config = wrap_config(config)
         embed_dim = config.hidden_size
         self.embeddings = CLIPTextEmbeddings(config)
         self.encoder = CLIPEncoder(config)

--- a/tests_adapters/methods/base.py
+++ b/tests_adapters/methods/base.py
@@ -63,13 +63,11 @@ class AdapterMethodBaseTestMixin:
         model.to(torch_device)
 
         # adapter is correctly added to config
-        self.assertTrue(name in model.config.adapters)
-        self.assertGreater(len(model.get_adapter(name)), 0)
+        self.assert_adapter_available(model, name)
 
         # remove the adapter again
         model.delete_adapter(name)
-        self.assertFalse(name in model.config.adapters)
-        self.assertEqual(len(model.get_adapter(name)), 0)
+        self.assert_adapter_unavailable(model, name)
 
         # check that weights are available and active
         has_weights = False
@@ -88,8 +86,7 @@ class AdapterMethodBaseTestMixin:
 
         # adapter is correctly added to config
         name = "first"
-        self.assertTrue(name in model.config.adapters)
-        self.assertEqual(adapter_config, model.config.adapters.get(name))
+        self.assert_adapter_available(model, name)
 
         first_adapter = model.get_adapter("first")
         second_adapter = model.get_adapter("second")
@@ -222,8 +219,8 @@ class AdapterMethodBaseTestMixin:
         model.add_adapter("dummy", config=adapter_config)
         self.add_head(model, "mrpc")
 
-        self.assertIn("mrpc", model.config.adapters.adapters)
-        self.assertIn("dummy", model.config.adapters.adapters)
+        self.assert_adapter_available(model, "mrpc")
+        self.assert_adapter_available(model, "dummy")
 
         # train the mrpc adapter -> should be activated & unfreezed
         model.train_adapter("mrpc")

--- a/tests_adapters/methods/test_adapter_common.py
+++ b/tests_adapters/methods/test_adapter_common.py
@@ -76,6 +76,7 @@ class BottleneckAdapterTestMixin(AdapterMethodBaseTestMixin):
                 adapter_output = model(**input_data)
                 # make sure the output is different without invertible adapter
                 del model.invertible_adapters[name]
+                self.assertFalse(name in model.invertible_adapters)
                 adapter_output_no_inv = model(**input_data)
                 self.assertEqual(len(adapter_output), len(adapter_output_no_inv))
                 self.assertFalse(torch.equal(adapter_output[0], adapter_output_no_inv[0]))

--- a/tests_adapters/test_adapter.py
+++ b/tests_adapters/test_adapter.py
@@ -61,6 +61,14 @@ class AdapterTestBase:
         )
         return GlueDataset(data_args, tokenizer=tokenizer, mode="train")
 
+    def assert_adapter_available(self, model, adapter_name):
+        self.assertTrue(adapter_name in model.config.adapters)
+        self.assertGreater(len(model.get_adapter(adapter_name)), 0)
+
+    def assert_adapter_unavailable(self, model, adapter_name):
+        self.assertFalse(adapter_name in model.config.adapters)
+        self.assertEqual(len(model.get_adapter(adapter_name)), 0)
+
 
 class VisionAdapterTestBase(AdapterTestBase):
     default_input_samples_shape = (3, 3, 224, 224)

--- a/tests_adapters/test_clip.py
+++ b/tests_adapters/test_clip.py
@@ -28,6 +28,7 @@ from .test_common import AdapterModelTesterMixin
 
 
 class CLIPVisionAdapterTestBase(VisionAdapterTestBase):
+    model_class = CLIPVisionModel
     config_class = CLIPVisionConfig
     config = make_config(
         CLIPVisionConfig,
@@ -60,6 +61,7 @@ class CLIPVisionAdapterTest(
 
 
 class CLIPTextAdapterTestBase(AdapterTestBase):
+    model_class = CLIPTextModel
     config_class = CLIPTextConfig
     config = make_config(
         CLIPTextConfig,

--- a/tests_adapters/test_clip.py
+++ b/tests_adapters/test_clip.py
@@ -15,15 +15,6 @@ from .methods import (
 from .test_adapter import AdapterTestBase, VisionAdapterTestBase, make_config
 from .test_adapter_backward_compability import CompabilityTestMixin
 from .test_adapter_fusion_common import AdapterFusionModelTestMixin
-from .test_common import AdapterModelTesterMixin
-
-# TODO
-# @require_torch
-# class CLIPAdapterModelTest(CLIPModelTest):
-#     all_model_classes = (
-#         CLIPAdapterModel,
-#     )
-#     fx_compatible = False
 
 
 class CLIPVisionAdapterTestBase(VisionAdapterTestBase):

--- a/tests_adapters/test_clip.py
+++ b/tests_adapters/test_clip.py
@@ -1,0 +1,129 @@
+import unittest
+
+from tests.models.clip.test_modeling_clip import *
+from transformers.testing_utils import require_torch
+
+from .methods import (
+    BottleneckAdapterTestMixin,
+    CompacterTestMixin,
+    IA3TestMixin,
+    LoRATestMixin,
+    PrefixTuningTestMixin,
+    UniPELTTestMixin,
+)
+from .test_adapter import AdapterTestBase, VisionAdapterTestBase, make_config
+from .test_adapter_backward_compability import CompabilityTestMixin
+from .test_adapter_composition import ParallelAdapterInferenceTestMixin, ParallelTrainingMixin
+from .test_adapter_fusion_common import AdapterFusionModelTestMixin
+from .test_adapter_heads import PredictionHeadModelTestMixin
+from .test_common import AdapterModelTesterMixin
+
+# TODO
+# @require_torch
+# class CLIPAdapterModelTest(CLIPModelTest):
+#     all_model_classes = (
+#         CLIPAdapterModel,
+#     )
+#     fx_compatible = False
+
+
+class CLIPVisionAdapterTestBase(VisionAdapterTestBase):
+    config_class = CLIPVisionConfig
+    config = make_config(
+        CLIPVisionConfig,
+        image_size=30,
+        hidden_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        intermediate_size=37,
+    )
+    feature_extractor_name = 'openai/clip-vit-base-patch32'
+
+
+@require_torch
+class CLIPVisionAdapterTest(
+    BottleneckAdapterTestMixin,
+    CompacterTestMixin,
+    IA3TestMixin,
+    LoRATestMixin,
+    PrefixTuningTestMixin,
+    UniPELTTestMixin,
+    AdapterFusionModelTestMixin,
+    CompabilityTestMixin,
+    PredictionHeadModelTestMixin,
+    ParallelAdapterInferenceTestMixin,
+    ParallelTrainingMixin,
+    CLIPVisionAdapterTestBase,
+    unittest.TestCase,
+):
+    pass
+
+
+class CLIPTextAdapterTestBase(AdapterTestBase):
+    config_class = CLIPTextConfig
+    config = make_config(
+        CLIPTextConfig,
+        hidden_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        intermediate_size=37,
+    )
+    tokenizer_name = 'openai/clip-vit-base-patch32'
+
+
+@require_torch
+class CLIPTextAdapterTest(
+    BottleneckAdapterTestMixin,
+    CompacterTestMixin,
+    IA3TestMixin,
+    LoRATestMixin,
+    PrefixTuningTestMixin,
+    UniPELTTestMixin,
+    AdapterFusionModelTestMixin,
+    CompabilityTestMixin,
+    PredictionHeadModelTestMixin,
+    ParallelAdapterInferenceTestMixin,
+    ParallelTrainingMixin,
+    CLIPTextAdapterTestBase,
+    unittest.TestCase,
+):
+    pass
+
+
+class CLIPAdapterTestBase(AdapterTestBase):
+    config_class = CLIPConfig
+    config = CLIPConfig.from_text_vision_configs(
+        CLIPTextConfig(
+            hidden_size=32,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            intermediate_size=37,
+        ),
+        CLIPVisionConfig(
+            image_size=30,
+            hidden_size=32,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            intermediate_size=37,
+        )
+    )
+    tokenizer_name = 'openai/clip-vit-base-patch32'
+
+
+@require_torch
+class CLIPAdapterTest(
+    BottleneckAdapterTestMixin,
+    CompacterTestMixin,
+    IA3TestMixin,
+    LoRATestMixin,
+    PrefixTuningTestMixin,
+    UniPELTTestMixin,
+    AdapterFusionModelTestMixin,
+    CompabilityTestMixin,
+    PredictionHeadModelTestMixin,
+    ParallelAdapterInferenceTestMixin,
+    ParallelTrainingMixin,
+    CLIPAdapterTestBase,
+    unittest.TestCase,
+):
+    pass

--- a/utils/check_adapters.py
+++ b/utils/check_adapters.py
@@ -18,6 +18,7 @@ MODELS_WITH_ADAPTERS = [
     "deberta",
     "deberta_v2",
     "vit",
+    "clip",
 ]
 
 IGNORE_NOT_IMPLEMENTING_MIXIN = [


### PR DESCRIPTION
Closes #296. This PR includes the following changes:

- Integration of all adapter methods into `CLIPModel`, `CLIPTextModel` & `CLIPVisionModel` classes.
- Modify prefix tuning implementation to support different values for `n_heads` & `input_size` at different locations: This is required for CLIP text & vision encoder prefixes to be stored in the same PT pool.
- Introduction of `InvertibleAdaptersWrapperMixin` for model classes that support invertible adapters in a sub-module.

Install with:

```
pip install git+https://github.com/calpt/adapter-transformers.git@dev/clip
```

Tested the implementation for our current project.