### PR TITLE
Move loading best adapter to the trainer class

### DIFF
--- a/src/transformers/adapters/trainer.py
+++ b/src/transformers/adapters/trainer.py
@@ -219,7 +219,9 @@ class AdapterTrainer(Trainer):
 
     def _load_best_model(self):
         model = self.model_wrapped if is_sagemaker_mp_enabled() else self.model
-        logger.info(f"Loading best adapter(s) from {self.state.best_model_checkpoint} (score: {self.state.best_metric}).")
+        logger.info(
+            f"Loading best adapter(s) from {self.state.best_model_checkpoint} (score: {self.state.best_metric})."
+        )
         # attempt to re-load all adapters from checkpoint
         for adapter in model.config.adapters.adapters:
             adapter_dir = os.path.join(self.state.best_model_checkpoint, adapter)
@@ -227,7 +229,8 @@ class AdapterTrainer(Trainer):
                 model.load_adapter(adapter_dir)
         if self.train_adapter_fusion:
             logger.info(
-                f"Loading best adapter fusion(s) from {self.state.best_model_checkpoint} (score: {self.state.best_metric})."
+                f"Loading best adapter fusion(s) from {self.state.best_model_checkpoint} (score:"
+                f" {self.state.best_metric})."
             )
             # attempt to re-load all adapter fusions from checkpoint
             for fusion in model.config.adapters.fusions:

--- a/src/transformers/adapters/trainer.py
+++ b/src/transformers/adapters/trainer.py
@@ -217,6 +217,25 @@ class AdapterTrainer(Trainer):
                 ):
                     self.model.load_head(os.path.join(resume_from_checkpoint, file_name))
 
+    def _load_best_model(self):
+        model = self.model_wrapped if is_sagemaker_mp_enabled() else self.model
+        logger.info(f"Loading best adapter(s) from {self.state.best_model_checkpoint} (score: {self.state.best_metric}).")
+        # attempt to re-load all adapters from checkpoint
+        for adapter in model.config.adapters.adapters:
+            adapter_dir = os.path.join(self.state.best_model_checkpoint, adapter)
+            if os.path.exists(adapter_dir):
+                model.load_adapter(adapter_dir)
+        if self.train_adapter_fusion:
+            logger.info(
+                f"Loading best adapter fusion(s) from {self.state.best_model_checkpoint} (score: {self.state.best_metric})."
+            )
+            # attempt to re-load all adapter fusions from checkpoint
+            for fusion in model.config.adapters.fusions:
+                fusion_dir = os.path.join(self.state.best_model_checkpoint, fusion)
+                if os.path.exists(fusion_dir):
+                    model.load_adapter_fusion(fusion_dir)
+        model.to(self.args.device)
+
 
 class AdapterTrainerCallback(TrainerCallback):
     def __init__(self, trainer):
@@ -231,27 +250,6 @@ class AdapterTrainerCallback(TrainerCallback):
                 "The pre-trained model weights are not frozen. For training adapters, please call the train_adapter()"
                 " method"
             )
-
-    def on_train_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
-        model = kwargs.pop("model")
-        if args.load_best_model_at_end and state.best_model_checkpoint is not None:
-
-            logger.info(f"Loading best adapter(s) from {state.best_model_checkpoint} (score: {state.best_metric}).")
-            # attempt to re-load all adapters from checkpoint
-            for adapter in model.config.adapters.adapters:
-                adapter_dir = os.path.join(state.best_model_checkpoint, adapter)
-                if os.path.exists(adapter_dir):
-                    model.load_adapter(adapter_dir)
-            if self.trainer.train_adapter_fusion:
-                logger.info(
-                    f"Loading best adapter fusion(s) from {state.best_model_checkpoint} (score: {state.best_metric})."
-                )
-                # attempt to re-load all adapter fusions from checkpoint
-                for fusion in model.config.adapters.fusions:
-                    fusion_dir = os.path.join(state.best_model_checkpoint, fusion)
-                    if os.path.exists(fusion_dir):
-                        model.load_adapter_fusion(fusion_dir)
-            model.to(args.device)
 
     def on_step_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         # apply adapter fusion weight regularization on the value matrix


### PR DESCRIPTION
When activating ```load_best_model_at_end```, AdapterTrainer first tries (unsuccessfully) to load the full model.
Moving the adapter loading code to ```_load_best_model()``` and thereby overwriting it should fix this.