### PR TITLE
Do not stale issues labeled as bugs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,10 +12,10 @@ jobs:
       issues: write
     
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v8
         with:
           repo-token: "${{ secrets.BOT_TOKEN }}"
-          exempt-issue-labels: 'do-not-stale,enhancement'
+          exempt-issue-labels: 'do-not-stale,enhancement,bug'
           stale-issue-message: 'This issue has been automatically marked as stale because it has been without activity for 90 days. This issue will be closed in 14 days unless you comment or remove the stale label.'
           close-issue-message: 'This issue was closed because it was stale for 14 days without any activity.'
           days-before-issue-stale: 90


### PR DESCRIPTION
The stale bot no longer marks and closes issues that have the "bug" label.